### PR TITLE
vfs: add --vfs and --vfs-manifest startup flags

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -3527,6 +3527,93 @@ added: v0.1.3
 
 Print node's version.
 
+### `--vfs-manifest=file`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `file` {string} Where to write the manifest. Must be an explicit path -
+  there is no default derived from the [`--vfs`][] target, so a run can
+  never silently overwrite the wrong file.
+
+Used together with a directory [`--vfs`][] target. The path of every file
+actually read through the mount during this run - by module resolution or
+by the program's own [`node:fs`][] calls - is appended, one per line, to
+`file` as soon as it's read.
+
+```bash
+node --vfs=./my-app --vfs-manifest=./my-app.manifest main.js
+# -> ./my-app.manifest lists every file this run actually touched
+```
+
+This lets you exercise an app once against its real source directory and
+come away with exactly the list of files it needed, without hand-picking
+what to bundle - useful as an input to building an archive of just those
+files, for example to run later via `--vfs=apparchive.zip`. Throws
+[`ERR_VFS_MANIFEST_REQUIRES_DIRECTORY`][] if [`--vfs`][]'s target is a file
+rather than a directory.
+
+Entries are appended immediately as each file is read, not buffered and
+flushed at the end, so the manifest reflects everything read up to
+whatever point the process reaches - including a process that's killed
+rather than exiting normally. Duplicate reads of the same file are only
+recorded once per thread; a [`Worker`][] appends to the very same manifest
+file directly, since it shares the real file system with the main thread.
+
+### `--vfs=target`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `target` {string} A directory or a ZIP archive to mount.
+
+Mounts `target` as a virtual file system ([`node:vfs`][]) and resolves the
+entry point (`process.argv[1]`) and all subsequent `require()`/`import`
+resolution against it, instead of against the real file system.
+
+* If `target` is a directory, it's mounted with a [`RealFSProvider`][] rooted
+  there. The files are already real, so mounting doesn't change what bytes
+  are read - it adds path containment, rejecting resolution that would
+  escape above `target` via `..`.
+* If `target` is a file, it's opened as a ZIP archive ([`zlib.ZipFile`][],
+  read-only) and mounted with a [`ZipProvider`][], turning `target`
+  itself into a virtual directory for module-resolution purposes (e.g.
+  `--vfs=/path/to/app.zip` resolves `/path/to/app.zip/index.js` inside the
+  archive).
+
+`process.argv[1]` becomes the mount root itself, as if `node <target>` had
+been run: the mount's own `package.json` `"main"` (or `index.js`) selects the
+entry point, and any positional command-line argument is the program's own
+(available from `process.argv[2]` onward), never an entry-point override. So a
+ZIP archive can be made directly executable by prepending a shebang line and
+marking it executable:
+
+```console
+$ (printf '#!/usr/bin/env -S node --vfs\n'; cat app.zip) > app && chmod +x app
+$ ./app arg1 arg2   # runs the archive's index.js with ['arg1', 'arg2']
+```
+
+Module resolution under `--vfs` is fully sandboxed: `package.json` lookups,
+`node_modules`-style resolution, and legacy `main` resolution never fall back
+to the real file system once they would step outside the mounted target - a
+dependency has to be inside the mounted directory or archive to be found.
+
+This only affects module _resolution_. The running program's own [`node:fs`][]
+calls to paths outside the mounted target work normally against the real file
+system; only paths under `target` are redirected, the same as any other
+[`node:vfs`][] mount.
+
+Native addons (`.node` files) are supported: from a directory-backed mount
+they're loaded directly from their real underlying path; from an
+archive-backed mount, the addon's bytes are extracted to a content-hashed
+file under the OS temporary directory before being loaded, and that file is
+best-effort removed when the process exits.
+
+A [`Worker`][] created from a process started with `--vfs` inherits the same
+mount unless its own `execArgv` explicitly overrides it.
+
 ### `--watch`
 
 <!-- YAML
@@ -3946,6 +4033,8 @@ one is included in the list below.
 * `--use-openssl-ca`
 * `--use-system-ca`
 * `--v8-pool-size`
+* `--vfs`
+* `--vfs-manifest`
 * `--watch-kill-signal`
 * `--watch-path`
 * `--watch-preserve-output`
@@ -4454,16 +4543,21 @@ node --stack-trace-limit=12 -p -e "Error.stackTraceLimit" # prints 12
 [`--require`]: #-r---require-module
 [`--use-env-proxy`]: #--use-env-proxy
 [`--use-system-ca`]: #--use-system-ca
+[`--vfs`]: #--vfstarget
 [`AsyncLocalStorage`]: async_context.md#class-asynclocalstorage
 [`Buffer`]: buffer.md#class-buffer
 [`CRYPTO_secure_malloc_init`]: https://www.openssl.org/docs/man3.0/man3/CRYPTO_secure_malloc_init.html
 [`ERR_INVALID_TYPESCRIPT_SYNTAX`]: errors.md#err_invalid_typescript_syntax
 [`ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`]: errors.md#err_unsupported_typescript_syntax
+[`ERR_VFS_MANIFEST_REQUIRES_DIRECTORY`]: errors.md#err_vfs_manifest_requires_directory
 [`NODE_OPTIONS`]: #node_optionsoptions
 [`NODE_USE_ENV_PROXY=1`]: #node_use_env_proxy1
 [`NO_COLOR`]: https://no-color.org
+[`RealFSProvider`]: vfs.md#class-realfsprovider
 [`Web Storage`]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API
+[`Worker`]: worker_threads.md#class-worker
 [`YoungGenerationSizeFromSemiSpaceSize`]: https://chromium.googlesource.com/v8/v8.git/+/refs/tags/10.3.129/src/heap/heap.cc#328
+[`ZipProvider`]: vfs.md#class-zipprovider
 [`dns.lookup()`]: dns.md#dnslookuphostname-options-callback
 [`dns.setDefaultResultOrder()`]: dns.md#dnssetdefaultresultorderorder
 [`dnsPromises.lookup()`]: dns.md#dnspromiseslookuphostname-options
@@ -4471,6 +4565,7 @@ node --stack-trace-limit=12 -p -e "Error.stackTraceLimit" # prints 12
 [`import` specifier]: esm.md#import-specifiers
 [`net.getDefaultAutoSelectFamilyAttemptTimeout()`]: net.md#netgetdefaultautoselectfamilyattempttimeout
 [`node:ffi`]: ffi.md
+[`node:fs`]: fs.md
 [`node:sqlite`]: sqlite.md
 [`node:stream/iter`]: stream_iter.md
 [`node:vfs`]: vfs.md
@@ -4481,6 +4576,7 @@ node --stack-trace-limit=12 -p -e "Error.stackTraceLimit" # prints 12
 [`v8.startupSnapshot.addDeserializeCallback()`]: v8.md#v8startupsnapshotadddeserializecallbackcallback-data
 [`v8.startupSnapshot.setDeserializeMainFunction()`]: v8.md#v8startupsnapshotsetdeserializemainfunctioncallback-data
 [`v8.startupSnapshot` API]: v8.md#startup-snapshot-api
+[`zlib.ZipFile`]: zlib.md#class-zlibzipfile
 [asynchronous module customization hooks]: module.md#asynchronous-customization-hooks
 [captured by the built-in snapshot of Node.js]: https://github.com/nodejs/node/blob/b19525a33cc84033af4addd0f80acd4dc33ce0cf/test/parallel/test-bootstrap-modules.js#L24
 [collecting code coverage from tests]: test.md#collecting-code-coverage

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -3490,6 +3490,21 @@ An attempt was made to use something that was already closed.
 While using the Performance Timing API (`perf_hooks`), no valid performance
 entry types are found.
 
+<a id="ERR_VFS_INVALID_TARGET"></a>
+
+### `ERR_VFS_INVALID_TARGET`
+
+The target passed to [`--vfs`][] does not exist, or is neither a regular file
+nor a directory.
+
+<a id="ERR_VFS_MANIFEST_REQUIRES_DIRECTORY"></a>
+
+### `ERR_VFS_MANIFEST_REQUIRES_DIRECTORY`
+
+[`--vfs-manifest`][] was used, but [`--vfs`][]'s target is not a directory.
+Recording reads into a manifest only makes sense when running against a real
+directory.
+
 <a id="ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING"></a>
 
 ### `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`
@@ -4644,6 +4659,8 @@ An error occurred trying to allocate memory. This should never happen.
 [`--force-fips`]: cli.md#--force-fips
 [`--no-addons`]: cli.md#--no-addons
 [`--unhandled-rejections`]: cli.md#--unhandled-rejectionsmode
+[`--vfs-manifest`]: cli.md#--vfs-manifest
+[`--vfs`]: cli.md#--vfstarget
 [`BoundSocket`]: net.md#class-netboundsocket
 [`Class: assert.AssertionError`]: assert.md#class-assertassertionerror
 [`ERR_INCOMPATIBLE_OPTION_PAIR`]: #err_incompatible_option_pair

--- a/doc/api/vfs.md
+++ b/doc/api/vfs.md
@@ -34,9 +34,11 @@ It does not isolate untrusted code from the host file system or from other
 Node.js capabilities. Code that can access a [`VirtualFileSystem`][] instance,
 mount it, select its provider, or pass paths to it is trusted application code.
 
-Mounting a VFS only redirects supported [`node:fs`][] calls whose resolved paths
-are under the mount point. It does not prevent code from using other paths or
-other Node.js APIs to access resources available to the process.
+Mounting a VFS only redirects supported [`node:fs`][] calls (and, since the
+CJS/ESM module loader ultimately resolves and reads files the same way,
+`require()`/`import` resolution) whose resolved paths are under the mount
+point. It does not prevent code from using other paths or other Node.js APIs
+to access resources available to the process.
 [`RealFSProvider`][] maps VFS paths under its configured root and rejects paths
 that resolve outside that root, but that check is not a security boundary.
 [`ZipProvider`][] has no real file-system paths of its own to escape; its
@@ -167,6 +169,10 @@ signatures as their [`node:fs`][] counterparts:
   `fstatSync`
 * Streams: `createReadStream`, `createWriteStream`
 * Watchers: `watch`, `watchFile`, `unwatchFile`
+* `toProviderPath(path)`: converts an absolute mounted path to the
+  provider-relative POSIX path passed to [`VirtualProvider`][] methods -
+  useful for code that needs to reach `vfs.provider` directly, bypassing
+  this class's own `fs`-shaped methods.
 
 #### Callback API
 

--- a/doc/api/vfs.md
+++ b/doc/api/vfs.md
@@ -38,10 +38,12 @@ Mounting a VFS only redirects supported [`node:fs`][] calls whose resolved paths
 are under the mount point. It does not prevent code from using other paths or
 other Node.js APIs to access resources available to the process.
 [`RealFSProvider`][] maps VFS paths under its configured root and rejects paths
-that resolve outside that root, but that check is not a security boundary. Do
-not rely on VFS to run untrusted code; use operating-system-level isolation,
-such as separate users, containers, or platform sandboxes, when a security
-boundary is required.
+that resolve outside that root, but that check is not a security boundary.
+[`ZipProvider`][] has no real file-system paths of its own to escape; its
+entries only ever exist within the archive's own namespace. Do not rely on VFS
+to run untrusted code; use operating-system-level isolation, such as separate
+users, containers, or platform sandboxes, when a security boundary is
+required.
 
 ## Basic usage
 
@@ -202,9 +204,6 @@ added: v26.4.0
 -->
 
 The base class for all VFS providers. Subclasses implement the essential
-primitives (`open`, `stat`, `readdir`, `mkdir`, `rmdir`, `unlink`,
-`rename`, ...) and inherit default implementations of the derived
-The base class for all VFS providers. Subclasses implement the essential
 primitives (such as `open`, `stat`, `readdir`, `mkdir`, `rmdir`, `unlink`,
 `rename`, etc.) and inherit default implementations of the derived
 methods (such as `readFile`, `writeFile`, `exists`, `copyFile`, `access`, etc.).
@@ -304,6 +303,55 @@ added: v26.4.0
 
 The resolved absolute path used as the root.
 
+## Class: `ZipProvider`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+A provider that exposes the entries of a ZIP archive - either a
+[`zlib.ZipBuffer`][] (in memory) or a [`zlib.ZipFile`][] (on disk) - through
+the VFS API. `provider.readonly` reflects the archive's own
+[`zipFile.writable`][] flag: a `ZipBuffer` is always writable, and a
+`ZipFile` is writable only when opened with `{ writable: true }`.
+
+Directories are recognized both explicitly (an entry whose name ends in `/`)
+and implicitly (any entry name starting with `"<dir>/"`). `readdir()` does
+not support `{ recursive: true }`. Because a ZIP member cannot be edited or
+read in place - only fully written or fully decompressed - a file opened for
+writing only commits its content (as a new archive entry) when the handle is
+closed.
+
+Every method has a synchronous counterpart (`openSync()`, `statSync()`,
+`readdirSync()`, and so on), backed by the equally complete synchronous
+surface [`zlib.ZipBuffer`][]/[`zlib.ZipFile`][] expose. As with those, the
+synchronous methods here block the Node.js event loop and further JavaScript
+execution until the operation - including any deflate/inflate pass -
+completes.
+
+```cjs
+const vfs = require('node:vfs');
+const zlib = require('node:zlib');
+const { readFileSync } = require('node:fs');
+
+async function main() {
+  const zip = new zlib.ZipBuffer(readFileSync('archive.zip'));
+  const archiveVfs = vfs.create(new vfs.ZipProvider(zip));
+
+  console.log(await archiveVfs.promises.readdir('/'));
+  await archiveVfs.promises.writeFile('/new.txt', 'hello');
+}
+main();
+```
+
+### `new ZipProvider(source)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `source` {zlib.ZipBuffer|zlib.ZipFile} An already-open archive.
+
 ## Implementation details
 
 ### `Stats` objects
@@ -322,6 +370,10 @@ fields use synthetic but stable values:
 [`RealFSProvider`]: #class-realfsprovider
 [`VirtualFileSystem`]: #class-virtualfilesystem
 [`VirtualProvider`]: #class-virtualprovider
+[`ZipProvider`]: #class-zipprovider
 [`fs.BigIntStats`]: fs.md#class-fsbigintstats
 [`fs.Stats`]: fs.md#class-fsstats
 [`node:fs`]: fs.md
+[`zipFile.writable`]: zlib.md#zipfilewritable
+[`zlib.ZipBuffer`]: zlib.md#class-zlibzipbuffer
+[`zlib.ZipFile`]: zlib.md#class-zlibzipfile

--- a/doc/node.1
+++ b/doc/node.1
@@ -1756,6 +1756,81 @@ amount of CPUs, but it may diverge in environments such as VMs or containers.
 .It Fl v , Fl -version
 Print node's version.
 .
+.It Fl -vfs-manifest Ns = Ns Ar file
+.Bl -bullet
+.It
+\fBfile\fR \fB<string>\fR Where to write the manifest. Must be an explicit path -
+there is no default derived from the \fB--vfs\fR target, so a run can
+never silently overwrite the wrong file.
+.El
+Used together with a directory \fB--vfs\fR target. The path of every file
+actually read through the mount during this run - by module resolution or
+by the program's own \fBnode:fs\fR calls - is appended, one per line, to
+\fBfile\fR as soon as it's read.
+.Bd -literal
+node --vfs=./my-app --vfs-manifest=./my-app.manifest main.js
+# -> ./my-app.manifest lists every file this run actually touched
+.Ed
+This lets you exercise an app once against its real source directory and
+come away with exactly the list of files it needed, without hand-picking
+what to bundle - useful as an input to building an archive of just those
+files, for example to run later via \fB--vfs=apparchive.zip\fR. Throws
+\fBERR_VFS_MANIFEST_REQUIRES_DIRECTORY\fR if \fB--vfs\fR's target is a file
+rather than a directory.
+Entries are appended immediately as each file is read, not buffered and
+flushed at the end, so the manifest reflects everything read up to
+whatever point the process reaches - including a process that's killed
+rather than exiting normally. Duplicate reads of the same file are only
+recorded once per thread; a \fBWorker\fR appends to the very same manifest
+file directly, since it shares the real file system with the main thread.
+.
+.It Fl -vfs Ns = Ns Ar target
+.Bl -bullet
+.It
+\fBtarget\fR \fB<string>\fR A directory or a ZIP archive to mount.
+.El
+Mounts \fBtarget\fR as a virtual file system (\fBnode:vfs\fR) and resolves the
+entry point (\fBprocess.argv[1]\fR) and all subsequent \fBrequire()\fR/\fBimport\fR
+resolution against it, instead of against the real file system.
+.Bl -bullet
+.It
+If \fBtarget\fR is a directory, it's mounted with a \fBRealFSProvider\fR rooted
+there. The files are already real, so mounting doesn't change what bytes
+are read - it adds path containment, rejecting resolution that would
+escape above \fBtarget\fR via \fB..\fR.
+.It
+If \fBtarget\fR is a file, it's opened as a ZIP archive (\fBzlib.ZipFile\fR,
+read-only) and mounted with a \fBZipProvider\fR, turning \fBtarget\fR
+itself into a virtual directory for module-resolution purposes (e.g.
+\fB--vfs=/path/to/app.zip\fR resolves \fB/path/to/app.zip/index.js\fR inside the
+archive).
+.El
+\fBprocess.argv[1]\fR becomes the mount root itself, as if \fBnode <target>\fR had
+been run: the mount's own \fBpackage.json\fR \fB"main"\fR (or \fBindex.js\fR) selects the
+entry point, and any positional command-line argument is the program's own
+(available from \fBprocess.argv[2]\fR onward), never an entry-point override. So a
+ZIP archive can be made directly executable by prepending a shebang line and
+marking it executable:
+.Bd -literal
+$ (printf '#!/usr/bin/env -S node --vfs\\n'; cat app.zip) > app && chmod +x app
+$ ./app arg1 arg2   # runs the archive's index.js with ['arg1', 'arg2']
+.Ed
+Module resolution under \fB--vfs\fR is fully sandboxed: \fBpackage.json\fR lookups,
+\fBnode_modules\fR-style resolution, and legacy \fBmain\fR resolution never fall back
+to the real file system once they would step outside the mounted target - a
+dependency has to be inside the mounted directory or archive to be found.
+This only affects module \fIresolution\fR. The running program's own \fBnode:fs\fR
+calls to paths outside the mounted target work normally against the real file
+system; only paths under \fBtarget\fR are redirected, the same as any other
+\fBnode:vfs\fR mount.
+Native addons (\fB.node\fR files) are supported: from a directory-backed mount
+they're loaded directly from their real underlying path; from an
+archive-backed mount, the addon's bytes are extracted to a content-hashed
+file under the OS temporary directory before being loaded, and that file is
+best-effort removed when the process exits.
+A \fBWorker\fR created from a process started with \fB--vfs\fR inherits the same
+mount unless its own \fBexecArgv\fR explicitly overrides it.
+.
 .It Fl -watch
 Starts Node.js in watch mode.
 When in watch mode, changes in the watched files cause the Node.js process to
@@ -2215,6 +2290,10 @@ one is included in the list below.
 \fB--use-system-ca\fR
 .It
 \fB--v8-pool-size\fR
+.It
+\fB--vfs\fR
+.It
+\fB--vfs-manifest\fR
 .It
 \fB--watch-kill-signal\fR
 .It

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1954,6 +1954,10 @@ E('ERR_USE_AFTER_CLOSE', '%s was closed', Error);
 // This should probably be a `TypeError`.
 E('ERR_VALID_PERFORMANCE_ENTRY_TYPE',
   'At least one valid performance entry type is required', Error);
+E('ERR_VFS_INVALID_TARGET',
+  '%s is not a valid --vfs target: must be an existing file or directory', Error);
+E('ERR_VFS_MANIFEST_REQUIRES_DIRECTORY',
+  '--vfs-manifest requires --vfs to target a directory, got %s', Error);
 E('ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING',
   'A dynamic import callback was not specified.', TypeError);
 E('ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG',

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -157,7 +157,7 @@ const {
 const assert = require('internal/assert');
 const fs = require('fs');
 const path = require('path');
-const internalFsBinding = internalBinding('fs');
+const { internalModuleStat: vfsInternalModuleStat } = require('internal/modules/vfs_resolution');
 const { safeGetenv } = internalBinding('credentials');
 const {
   getCjsConditions,
@@ -278,7 +278,7 @@ function stat(filename) {
     const result = statCache.get(filename);
     if (result !== undefined) { return result; }
   }
-  const result = internalFsBinding.internalModuleStat(filename);
+  const result = vfsInternalModuleStat(filename);
   if (statCache !== null && result >= 0) {
     // Only set cache when `internalModuleStat(filename)` succeeds.
     statCache.set(filename, result);
@@ -2101,7 +2101,9 @@ Module._extensions['.json'] = function(module, filename) {
  */
 Module._extensions['.node'] = function(module, filename) {
   // Be aware this doesn't use `content`
-  return process.dlopen(module, path.toNamespacedPath(filename));
+  const { resolveAddonRealPath } = require('internal/modules/vfs_addons');
+  const realFilename = resolveAddonRealPath(filename) ?? filename;
+  return process.dlopen(module, path.toNamespacedPath(realFilename));
 };
 
 /**

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -10,7 +10,8 @@ const {
 } = primordials;
 const { getOptionValue } = require('internal/options');
 const { getValidatedPath } = require('internal/fs/utils');
-const fsBindings = internalBinding('fs');
+const { getFormatOfExtensionlessFile: vfsGetFormatOfExtensionlessFile } =
+  require('internal/modules/vfs_resolution');
 const { internal: internalConstants } = internalBinding('constants');
 
 const extensionFormatMap = {
@@ -66,7 +67,7 @@ function mimeToFormat(mime) {
  */
 function getFormatOfExtensionlessFile(url) {
   const path = getValidatedPath(url);
-  switch (fsBindings.getFormatOfExtensionlessFile(path)) {
+  switch (vfsGetFormatOfExtensionlessFile(path)) {
     case internalConstants.EXTENSIONLESS_FORMAT_WASM:
       return 'wasm';
     default:

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -32,7 +32,10 @@ const { sep, posix: { relative: relativePosixPath }, resolve, join } = require('
 const { URL, pathToFileURL, fileURLToPath, isURL, URLParse } = require('internal/url');
 const { getCWDURL, setOwnProperty, kEmptyObject } = require('internal/util');
 const { canParse: URLCanParse } = internalBinding('url');
-const { legacyMainResolve: FSLegacyMainResolve } = internalBinding('fs');
+const {
+  legacyMainResolve: FSLegacyMainResolve,
+  internalModuleStat: vfsInternalModuleStat,
+} = require('internal/modules/vfs_resolution');
 const {
   ERR_INPUT_TYPE_NOT_ALLOWED,
   ERR_INVALID_ARG_TYPE,
@@ -49,7 +52,6 @@ const {
 const { defaultGetFormatWithoutErrors } = require('internal/modules/esm/get_format');
 const { getConditionsSet } = require('internal/modules/esm/utils');
 const packageJsonReader = require('internal/modules/package_json_reader');
-const internalFsBinding = internalBinding('fs');
 
 /**
  * @typedef {import('internal/modules/esm/package_config.js').PackageConfig} PackageConfig
@@ -245,7 +247,7 @@ function finalizeResolution(resolved, base, preserveSymlinks) {
     throw err;
   }
 
-  const stats = internalFsBinding.internalModuleStat(
+  const stats = vfsInternalModuleStat(
     StringPrototypeEndsWith(path, '/') ? StringPrototypeSlice(path, -1) : path,
   );
 

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -24,10 +24,15 @@ const {
   },
 } = require('internal/errors');
 const { kEmptyObject } = require('internal/util');
-const modulesBinding = internalBinding('modules');
 const path = require('path');
 const { validateString } = require('internal/validators');
-const internalFsBinding = internalBinding('fs');
+const {
+  internalModuleStat: vfsInternalModuleStat,
+  readPackageJSON: vfsReadPackageJSON,
+  getNearestParentPackageJSON: vfsGetNearestParentPackageJSON,
+  getPackageScopeConfig: vfsGetPackageScopeConfig,
+  getPackageType: vfsGetPackageType,
+} = require('internal/modules/vfs_resolution');
 
 
 /**
@@ -122,7 +127,7 @@ const requiresJSONParse = (value) => (value !== undefined && (value[0] === '[' |
 function read(jsonPath, { base, specifier, isESM } = kEmptyObject) {
   // This function will be called by both CJS and ESM, so we need to make sure
   // non-null attributes are converted to strings.
-  const parsed = modulesBinding.readPackageJSON(
+  const parsed = vfsReadPackageJSON(
     jsonPath,
     isESM,
     base == null ? undefined : `${base}`,
@@ -170,7 +175,7 @@ function getNearestParentPackageJSON(checkPath) {
     return deserializedPackageJSONCache.get(parentPackageJSONPath);
   }
 
-  const result = modulesBinding.getNearestParentPackageJSON(checkPath);
+  const result = vfsGetNearestParentPackageJSON(checkPath);
   const packageConfig = deserializePackageJSON(checkPath, result);
 
   moduleToParentPackageJSONCache.set(checkPath, packageConfig.path);
@@ -190,7 +195,7 @@ function getNearestParentPackageJSON(checkPath) {
  * @returns {import('typings/internalBinding/modules').PackageConfig} - The package configuration.
  */
 function getPackageScopeConfig(resolved) {
-  const result = modulesBinding.getPackageScopeConfig(`${resolved}`);
+  const result = vfsGetPackageScopeConfig(`${resolved}`);
 
   if (ArrayIsArray(result)) {
     const { data, exists, path } = deserializePackageJSON(`${resolved}`, result);
@@ -219,8 +224,7 @@ function getPackageScopeConfig(resolved) {
  * @returns {string}
  */
 function getPackageType(url) {
-  const type = modulesBinding.getPackageType(`${url}`);
-  return type ?? 'none';
+  return vfsGetPackageType(`${url}`);
 }
 
 const invalidPackageNameRegEx = /^\.|%|\\/;
@@ -280,7 +284,7 @@ function getPackageJSONURL(specifier, base) {
   let packageJSONPath = fileURLToPath(packageJSONUrl);
   let lastPath;
   do {
-    const stat = internalFsBinding.internalModuleStat(
+    const stat = vfsInternalModuleStat(
       StringPrototypeSlice(packageJSONPath, 0, packageJSONPath.length - 13),
     );
     // Check for !stat.isDirectory()

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -5,7 +5,7 @@ const {
   globalThis,
 } = primordials;
 
-const { getNearestParentPackageJSONType } = internalBinding('modules');
+const { getNearestParentPackageJSONType } = require('internal/modules/vfs_resolution');
 const { getOptionValue } = require('internal/options');
 const path = require('path');
 const { pathToFileURL, URL } = require('internal/url');

--- a/lib/internal/modules/vfs_addons.js
+++ b/lib/internal/modules/vfs_addons.js
@@ -1,0 +1,106 @@
+'use strict';
+
+// Native addon ('.node' file) loading for a path inside an active VFS
+// mount (whether mounted via the --vfs CLI flag or from plain userland
+// code - internal/vfs/setup.js's activeVFSList covers both the same way).
+// `dlopen()` needs a real path on disk - there's nothing to intercept at
+// the fs-module level for that - so:
+//  - a directory-backed mount (RealFSProvider) already has a real
+//    underlying file; translate the virtual path back to it and dlopen
+//    that directly, no copying needed.
+//  - an archive-backed mount (ZipProvider) has no real backing file;
+//    extract the entry's bytes to a real temp file named by content hash
+//    (so repeated loads of the same addon within this process reuse the
+//    same extraction instead of re-extracting) and dlopen that instead.
+//    Each process gets its own pid-scoped temp directory - sharing one
+//    across processes would let one process delete or overwrite a file
+//    another process still has mapped. Extracted files are best-effort
+//    removed when the process exits.
+
+const {
+  SafeSet,
+} = primordials;
+
+const { createHash } = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { findVFSForPath } = require('internal/vfs/setup');
+
+const extractedAddons = new SafeSet();
+let cleanupRegistered = false;
+
+function registerCleanup() {
+  if (cleanupRegistered) { return; }
+  cleanupRegistered = true;
+  process.once('exit', () => {
+    for (const extractedPath of extractedAddons) {
+      try {
+        fs.unlinkSync(extractedPath);
+      } catch {
+        // Best effort: the file may still be mapped (Windows keeps loaded
+        // DLLs locked).
+      }
+    }
+  });
+}
+
+/**
+ * Extracts a VFS-internal addon to a real, content-hashed temp file (or
+ * reuses one already extracted with the same content) and returns its path.
+ * @param {import('internal/vfs/file_system').VirtualFileSystem} vfs
+ * @param {string} vfsPath
+ * @returns {string}
+ */
+function extractAddon(vfs, vfsPath) {
+  const content = vfs.readFileSync(vfsPath);
+  const hash = createHash('sha256').update(content).digest('hex');
+  const dir = path.join(os.tmpdir(), `node-vfs-addons-${process.pid}`);
+  const dest = path.join(dir, `${hash}.node`);
+
+  if (!fs.existsSync(dest)) {
+    fs.mkdirSync(dir, { recursive: true });
+    const tmpDest = `${dest}.${process.pid}.tmp`;
+    fs.writeFileSync(tmpDest, content);
+    try {
+      fs.renameSync(tmpDest, dest);
+    } catch (err) {
+      // Another thread in this process (e.g. a worker_thread, which shares
+      // our pid and thus our temp directory) extracting the same content
+      // may have won the race; that's fine as long as the destination
+      // exists now.
+      try {
+        fs.unlinkSync(tmpDest);
+      } catch {
+        // Ignore: best-effort cleanup of our own losing-race temp file.
+      }
+      if (!fs.existsSync(dest)) { throw err; }
+    }
+  }
+
+  extractedAddons.add(dest);
+  registerCleanup();
+  return dest;
+}
+
+/**
+ * Resolves the real, on-disk path to `dlopen()` for a native addon whose
+ * virtual path is under an active VFS mount.
+ * @param {string} vfsPath
+ * @returns {string | null} The real path to dlopen, or null if `vfsPath` is
+ *   not under an active VFS mount (the caller should dlopen it unchanged).
+ */
+function resolveAddonRealPath(vfsPath) {
+  const found = findVFSForPath(vfsPath);
+  if (found === null) { return null; }
+  const { vfs, normalized } = found;
+  const provider = vfs.provider;
+  if (typeof provider.toRealPath === 'function') {
+    return provider.toRealPath(vfs.toProviderPath(normalized));
+  }
+  return extractAddon(vfs, normalized);
+}
+
+module.exports = {
+  resolveAddonRealPath,
+};

--- a/lib/internal/modules/vfs_resolution.js
+++ b/lib/internal/modules/vfs_resolution.js
@@ -1,0 +1,287 @@
+'use strict';
+
+// The CJS/ESM loader mostly resolves and reads files through the public
+// `fs` module, which any active VFS mount (internal/vfs/setup.js's
+// activeVFSList, populated by every vfs.mount() call - whether from the
+// --vfs CLI flag or from plain userland code) already redirects for any
+// path under that mount. But a handful of module-resolution primitives
+// bypass `fs` entirely and call straight into
+// internalBinding('fs')/internalBinding('modules'), hitting the real
+// filesystem no matter what's mounted. This file provides VFS-aware
+// replacements for exactly those primitives, each matching the native
+// function's contract precisely: when the given path is under an active
+// VFS mount, do the equivalent work against that VirtualFileSystem
+// (bounded at the mount's own root - never falling through past it into the
+// real, unmounted parent directory); otherwise call the real native
+// binding, unchanged.
+
+const {
+  ArrayIsArray,
+  JSONParse,
+  JSONStringify,
+  StringPrototypeEndsWith,
+} = primordials;
+
+const { Buffer } = require('buffer');
+const path = require('path');
+const {
+  codes: {
+    ERR_INVALID_PACKAGE_CONFIG,
+  },
+} = require('internal/errors');
+const { findVFSForPath } = require('internal/vfs/setup');
+
+const internalFsBinding = internalBinding('fs');
+const modulesBinding = internalBinding('modules');
+const { internal: internalConstants } = internalBinding('constants');
+
+/**
+ * VFS-aware replacement for internalBinding('fs').internalModuleStat: -2
+ * (not found/error), 0 (file), or 1 (directory) - callers only ever check
+ * `>= 0` vs not, so any error collapses to -2 like a plain ENOENT would.
+ * @param {string} filename
+ * @returns {number}
+ */
+function internalModuleStat(filename) {
+  const found = findVFSForPath(filename);
+  if (found === null) { return internalFsBinding.internalModuleStat(filename); }
+  try {
+    return found.vfs.statSync(found.normalized).isDirectory() ? 1 : 0;
+  } catch {
+    return -2;
+  }
+}
+
+/**
+ * Reads and minimally parses a package.json at an exact path, matching the
+ * shape `src/node_modules.cc`'s `PackageConfig::Serialize` produces:
+ * `[name, main, type, imports, exports, filePath]`, or `undefined` if the
+ * file doesn't exist. `imports`/`exports` are re-serialized to a JSON string
+ * when they're objects/arrays, exactly like the native reader, so
+ * `package_json_reader.js`'s existing lazy-parse-on-access getters keep
+ * working unchanged.
+ * @param {import('internal/vfs/file_system').VirtualFileSystem} vfs
+ * @param {string} jsonPath
+ * @returns {Array | undefined}
+ */
+function readPackageJSONFile(vfs, jsonPath) {
+  let raw;
+  try {
+    raw = vfs.readFileSync(jsonPath, 'utf8');
+  } catch (err) {
+    if (err?.code === 'ENOENT' || err?.code === 'ENOTDIR') { return undefined; }
+    throw err;
+  }
+  let parsed;
+  try {
+    parsed = JSONParse(raw);
+  } catch (err) {
+    throw new ERR_INVALID_PACKAGE_CONFIG(jsonPath, undefined, err.message);
+  }
+  if (parsed === null || typeof parsed !== 'object' || ArrayIsArray(parsed)) {
+    throw new ERR_INVALID_PACKAGE_CONFIG(jsonPath, undefined, 'not an object');
+  }
+  const name = typeof parsed.name === 'string' ? parsed.name : undefined;
+  const main = typeof parsed.main === 'string' ? parsed.main : undefined;
+  const type = parsed.type === 'commonjs' || parsed.type === 'module' ? parsed.type : 'none';
+  const toRaw = (value) => {
+    if (typeof value === 'string') { return value; }
+    if (typeof value === 'object' && value !== null) { return JSONStringify(value); }
+    return undefined;
+  };
+  const imports = toRaw(parsed.imports);
+  const exports = toRaw(parsed.exports);
+  return [name, main, type, imports, exports, jsonPath];
+}
+
+/**
+ * VFS-aware replacement for internalBinding('modules').readPackageJSON:
+ * reads one exact package.json path (no directory walking).
+ * @param {string} jsonPath
+ * @param {boolean} isESM
+ * @param {string} [base]
+ * @param {string} [specifier]
+ * @returns {Array | undefined}
+ */
+function readPackageJSON(jsonPath, isESM, base, specifier) {
+  const found = findVFSForPath(jsonPath);
+  if (found === null) { return modulesBinding.readPackageJSON(jsonPath, isESM, base, specifier); }
+  return readPackageJSONFile(found.vfs, found.normalized);
+}
+
+/**
+ * Shared directory-climbing algorithm behind getNearestParentPackageJSON()/
+ * getNearestParentPackageJSONType(): starting at the directory containing
+ * `fromPath`, look for a package.json, then climb toward the mount's root -
+ * stopping (not found) at a directory literally named node_modules, or the
+ * moment climbing further would step outside the mount, whichever comes
+ * first. Never falls through to the real parent directory above the mount.
+ * @param {import('internal/vfs/file_system').VirtualFileSystem} vfs
+ * @param {string} fromPath
+ * @returns {Array | undefined}
+ */
+function findPackageJSONUpward(vfs, fromPath) {
+  let dir = path.dirname(fromPath);
+  while (true) {
+    if (path.basename(dir) === 'node_modules') { return undefined; }
+    const found = readPackageJSONFile(vfs, path.join(dir, 'package.json'));
+    if (found !== undefined) { return found; }
+    if (dir === vfs.mountPoint) { return undefined; }
+    const parent = path.dirname(dir);
+    if (parent === dir) { return undefined; }
+    dir = parent;
+  }
+}
+
+/**
+ * VFS-aware replacement for
+ * internalBinding('modules').getNearestParentPackageJSON.
+ * @param {string} checkPath
+ * @returns {Array | undefined}
+ */
+function getNearestParentPackageJSON(checkPath) {
+  const found = findVFSForPath(checkPath);
+  if (found === null) { return modulesBinding.getNearestParentPackageJSON(checkPath); }
+  return findPackageJSONUpward(found.vfs, found.normalized);
+}
+
+/**
+ * VFS-aware replacement for
+ * internalBinding('modules').getNearestParentPackageJSONType.
+ * @param {string} checkPath
+ * @returns {string | undefined}
+ */
+function getNearestParentPackageJSONType(checkPath) {
+  const found = findVFSForPath(checkPath);
+  if (found === null) { return modulesBinding.getNearestParentPackageJSONType(checkPath); }
+  const result = findPackageJSONUpward(found.vfs, found.normalized);
+  return result === undefined ? undefined : result[2];
+}
+
+/**
+ * Shared directory-climbing algorithm behind getPackageScopeConfig()/
+ * getPackageType(): starting at the *same* directory as `resolvedPath`
+ * itself (matching the native "./package.json"-relative-to-self behavior),
+ * climb toward the mount root, stopping at a candidate that would live
+ * directly inside a node_modules directory, or at the mount's own root.
+ * @param {import('internal/vfs/file_system').VirtualFileSystem} vfs
+ * @param {string} resolvedPath
+ * @param {boolean} returnOnlyType
+ * @returns {Array | string | undefined}
+ */
+function findPackageScopeConfig(vfs, resolvedPath, returnOnlyType) {
+  const nodeModulesBoundary = path.join('node_modules', 'package.json');
+  let dir = path.dirname(resolvedPath);
+  while (true) {
+    const candidate = path.join(dir, 'package.json');
+    if (StringPrototypeEndsWith(candidate, nodeModulesBoundary)) { break; }
+    const found = readPackageJSONFile(vfs, candidate);
+    if (found !== undefined) { return returnOnlyType ? found[2] : found; }
+    if (dir === vfs.mountPoint) { break; }
+    const parent = path.dirname(dir);
+    if (parent === dir) { break; }
+    dir = parent;
+  }
+  return returnOnlyType ? undefined : path.join(dir, 'package.json');
+}
+
+/**
+ * @param {string | URL} resolved
+ * @returns {object | string}
+ */
+function getPackageScopeConfig(resolved) {
+  const resolvedPath = `${resolved}`;
+  const found = findVFSForPath(resolvedPath);
+  if (found === null) { return modulesBinding.getPackageScopeConfig(resolvedPath); }
+  return findPackageScopeConfig(found.vfs, found.normalized, false);
+}
+
+/**
+ * @param {string | URL} url
+ * @returns {string}
+ */
+function getPackageType(url) {
+  const resolvedPath = `${url}`;
+  const found = findVFSForPath(resolvedPath);
+  if (found === null) { return modulesBinding.getPackageType(resolvedPath) ?? 'none'; }
+  return findPackageScopeConfig(found.vfs, found.normalized, true) ?? 'none';
+}
+
+// Same order/semantics as esm/resolve.js's own legacyMainResolveExtensions -
+// duplicated here (rather than imported) to avoid a dependency cycle between
+// this file and the ESM resolver; both must stay in sync with
+// src/node_file.cc's `legacy_main_extensions`.
+const legacyMainExtensions = [
+  '', '.js', '.json', '.node',
+  '/index.js', '/index.json', '/index.node',
+  '/index.js', '/index.json', '/index.node',
+];
+const kWithMainEnd = 7;
+
+/**
+ * VFS-aware replacement for internalBinding('fs').legacyMainResolve.
+ * @param {string} packagePath
+ * @param {string} [main]
+ * @param {string} [base]
+ * @returns {number | undefined}
+ */
+function legacyMainResolve(packagePath, main, base) {
+  const found = findVFSForPath(packagePath);
+  if (found === null) { return internalFsBinding.legacyMainResolve(packagePath, main, base); }
+  const { vfs, normalized } = found;
+
+  const isFile = (candidate) => {
+    try {
+      return !vfs.statSync(candidate).isDirectory();
+    } catch {
+      return false;
+    }
+  };
+
+  if (typeof main === 'string') {
+    const initial = path.resolve(normalized, main);
+    for (let i = 0; i < kWithMainEnd; i++) {
+      if (isFile(initial + legacyMainExtensions[i])) { return i; }
+    }
+  }
+
+  const initial = path.resolve(normalized, './index');
+  for (let i = kWithMainEnd; i < legacyMainExtensions.length; i++) {
+    if (isFile(initial + legacyMainExtensions[i])) { return i; }
+  }
+  return undefined;
+}
+
+const WASM_MAGIC = Buffer.from([0x00, 0x61, 0x73, 0x6d]);
+
+/**
+ * VFS-aware replacement for
+ * internalBinding('fs').getFormatOfExtensionlessFile.
+ * @param {string} filePath
+ * @returns {number}
+ */
+function getFormatOfExtensionlessFile(filePath) {
+  const found = findVFSForPath(filePath);
+  if (found === null) { return internalFsBinding.getFormatOfExtensionlessFile(filePath); }
+  try {
+    const content = found.vfs.readFileSync(found.normalized);
+    if (content.length >= 4 && content[0] === WASM_MAGIC[0] && content[1] === WASM_MAGIC[1] &&
+        content[2] === WASM_MAGIC[2] && content[3] === WASM_MAGIC[3]) {
+      return internalConstants.EXTENSIONLESS_FORMAT_WASM;
+    }
+  } catch {
+    // Matches the native function's own fallback on open/read failure.
+  }
+  return internalConstants.EXTENSIONLESS_FORMAT_JAVASCRIPT;
+}
+
+module.exports = {
+  internalModuleStat,
+  readPackageJSON,
+  getNearestParentPackageJSON,
+  getNearestParentPackageJSONType,
+  getPackageScopeConfig,
+  getPackageType,
+  legacyMainResolve,
+  getFormatOfExtensionlessFile,
+};

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -2,6 +2,7 @@
 
 const {
   ArrayPrototypeForEach,
+  ArrayPrototypeSplice,
   Date,
   DatePrototypeGetDate,
   DatePrototypeGetFullYear,
@@ -32,6 +33,7 @@ const {
 const {
   ERR_MISSING_OPTION,
   ERR_ACCESS_DENIED,
+  ERR_VFS_INVALID_TARGET,
 } = require('internal/errors').codes;
 const assert = require('internal/assert');
 const {
@@ -107,8 +109,17 @@ function prepareExecution(options) {
 
   refreshRuntimeOptions();
 
+  // Needed before setupVfsMount() below: mounting a VFS logs through
+  // internal/util/debuglog, which throws if used before this runs.
+  setupDebugEnv();
+
+  // If --vfs is active, mount it before resolving the main entry point below,
+  // since that resolution needs to anchor on the mount's root rather than
+  // the real cwd.
+  const vfsMountTarget = setupVfsMount();
+
   // Patch the process object and get the resolved main entry point.
-  const mainEntry = patchProcessObject(expandArgv1);
+  const mainEntry = patchProcessObject(expandArgv1, vfsMountTarget);
   setupTraceCategoryState();
   setupInspectorHooks();
   setupNetworkInspection();
@@ -124,7 +135,6 @@ function prepareExecution(options) {
   setupWebsocket();
   setupEventsource();
   setupCodeCoverage();
-  setupDebugEnv();
   // Process initial diagnostic reporting configuration, if present.
   initializeReport();
 
@@ -260,9 +270,11 @@ function refreshRuntimeOptions() {
  * Replace `process.argv[1]` with the resolved absolute file path of the entry point, if found.
  * @param {boolean} expandArgv1 - Whether to replace `process.argv[1]` with the resolved absolute file path of
  *   the main entry point.
+ * @param {string} [vfsMountTarget] - The resolved --vfs target, if active; process.argv[1] is then unconditionally
+ *   set to it, and whatever the user actually passed shifts down to argv[2] onward.
  * @returns {string}
  */
-function patchProcessObject(expandArgv1) {
+function patchProcessObject(expandArgv1, vfsMountTarget) {
   const binding = internalBinding('process_methods');
   binding.patchProcessObject(process);
 
@@ -281,10 +293,29 @@ function patchProcessObject(expandArgv1) {
 
   /** @type {string} */
   let mainEntry;
-  // If requested, update process.argv[1] to replace whatever the user provided with the resolved absolute file path of
-  // the entry point.
-  if (expandArgv1 && process.argv[1] && process.argv[1][0] !== '-') {
-    // Expand process.argv[1] into a full path.
+  if (expandArgv1 && vfsMountTarget !== undefined) {
+    // With --vfs active, argv[1] is unconditionally the mount root itself -
+    // as if the user had run `node <mountRoot>` directly - so normal
+    // package.json "main"/index.js resolution decides what actually runs,
+    // the same way it would for any other directory. A positional argument
+    // is never an entry-point override here; it is a user argument, so shift
+    // it (and everything after it) down to argv[2] onward. This is what a
+    // self-mounting shebang line (`#!/usr/bin/env node --vfs`) needs: the
+    // kernel appends the script's own path as the argument that becomes
+    // --vfs's value, so the first argument the *user* supplies on the
+    // command line is what would otherwise land in argv[1] and be misread
+    // as an entry-point path instead of the app's own argument. Workers are
+    // unaffected - they are prepared with expandArgv1 false and name their
+    // entry through `new Worker(filename)`, not argv[1].
+    mainEntry = vfsMountTarget;
+    if (process.argv[1] !== undefined) {
+      ArrayPrototypeSplice(process.argv, 1, 0, mainEntry);
+    } else {
+      process.argv[1] = mainEntry;
+    }
+  } else if (expandArgv1 && process.argv[1] && process.argv[1][0] !== '-') {
+    // If requested, update process.argv[1] to replace whatever the user
+    // provided with the resolved absolute file path of the entry point.
     const path = require('path');
     try {
       mainEntry = path.resolve(process.argv[1]);
@@ -439,6 +470,63 @@ function setupVfs() {
 
   const { BuiltinModule } = require('internal/bootstrap/realm');
   BuiltinModule.allowRequireByUsers('vfs');
+}
+
+/**
+ * Mounts the target given via --vfs (a directory or a ZIP archive) at its
+ * own resolved path. Module resolution then finds it the same way any
+ * other VFS mount is found, via internal/vfs/setup.js's activeVFSList.
+ * Must run before patchProcessObject() resolves process.argv[1], since that
+ * resolution needs to anchor on the mount's root rather than the real cwd
+ * when --vfs is active.
+ * @returns {string | undefined} The resolved --vfs target, or undefined if
+ *   --vfs wasn't passed.
+ */
+function setupVfsMount() {
+  const target = getOptionValue('--vfs');
+  if (!target) {
+    if (getOptionValue('--vfs-manifest')) {
+      throw new ERR_MISSING_OPTION('--vfs (required when --vfs-manifest is used)');
+    }
+    return undefined;
+  }
+  emitExperimentalWarning('--vfs');
+
+  const fs = require('fs');
+  const path = require('path');
+  const resolvedTarget = path.resolve(target);
+
+  let stats;
+  try {
+    stats = fs.statSync(resolvedTarget);
+  } catch {
+    throw new ERR_VFS_INVALID_TARGET(resolvedTarget);
+  }
+
+  let provider;
+  const isDirectory = stats.isDirectory();
+  if (isDirectory) {
+    const { RealFSProvider } = require('internal/vfs/providers/real');
+    provider = new RealFSProvider(resolvedTarget);
+  } else if (stats.isFile()) {
+    const { ZipProvider } = require('internal/vfs/providers/archive');
+    const { ZipFile } = require('internal/zip');
+    provider = new ZipProvider(ZipFile.openSync(resolvedTarget));
+  } else {
+    throw new ERR_VFS_INVALID_TARGET(resolvedTarget);
+  }
+
+  const manifestTarget = getOptionValue('--vfs-manifest');
+  if (manifestTarget) {
+    const { startCliVfsManifest } = require('internal/vfs/cli_manifest');
+    startCliVfsManifest(provider, resolvedTarget, isDirectory, path.resolve(manifestTarget));
+  }
+
+  const { VirtualFileSystem } = require('internal/vfs/file_system');
+  const vfs = new VirtualFileSystem(provider, { emitExperimentalWarning: false });
+  vfs.mount(resolvedTarget);
+
+  return resolvedTarget;
 }
 
 function setupWebStorage() {

--- a/lib/internal/vfs/cli_manifest.js
+++ b/lib/internal/vfs/cli_manifest.js
@@ -1,0 +1,78 @@
+'use strict';
+
+// When --vfs-manifest=<file> is active alongside a directory-backed --vfs
+// mount, every file actually read through that mount during this run -
+// whether by module resolution or by the running program's own node:fs
+// calls (e.g. fs.readFile(`${__dirname}/data.txt`) is a completely ordinary
+// pattern, not just requires/imports) - has its VFS-relative path appended,
+// one per line, to <file> as soon as it's read, rather than buffered and
+// flushed at exit: that way nothing is lost if the process is killed rather
+// than exiting normally. Since worker threads share the real filesystem
+// with the main thread (they're threads, not separate processes), every
+// worker just appends to that very same file directly - O_APPEND writes
+// don't interleave/overwrite each other across threads (or processes), so
+// no cross-thread coordination is needed beyond that.
+//
+// This hooks internal/vfs/provider.js's kReadObserver slot rather than
+// patching any method: readFile()/readFileSync() are the one place every
+// read converges (module loader or direct node:fs calls alike, since both
+// route through the same provider), so checking there - once, from code
+// that already runs on every read - is enough on its own.
+
+const {
+  RegExpPrototypeSymbolReplace,
+  SafeSet,
+} = primordials;
+
+const { kReadObserver } = require('internal/vfs/provider');
+
+const kLeadingSlashRE = /^\/+/;
+
+/**
+ * @param {import('internal/vfs/provider').VirtualProvider} provider The
+ *   provider backing the --vfs mount (a RealFSProvider, always, since
+ *   --vfs-manifest requires a directory target).
+ * @param {string} resolvedTarget The resolved --vfs directory target (used
+ *   only for the error message below).
+ * @param {boolean} isDirectory Whether resolvedTarget is a directory -
+ *   already known by the caller (setupVfsMount()), which classified it to
+ *   pick a provider in the first place.
+ * @param {string} manifestPath The resolved --vfs-manifest output path.
+ */
+function startCliVfsManifest(provider, resolvedTarget, isDirectory, manifestPath) {
+  if (!isDirectory) {
+    const {
+      codes: {
+        ERR_VFS_MANIFEST_REQUIRES_DIRECTORY,
+      },
+    } = require('internal/errors');
+    throw new ERR_VFS_MANIFEST_REQUIRES_DIRECTORY(resolvedTarget);
+  }
+
+  const fs = require('fs');
+  if (internalBinding('worker').isMainThread) {
+    // Only the real main thread starts a fresh manifest; a worker thread
+    // appends to whatever the main thread (or an earlier-started worker)
+    // already wrote, rather than wiping it out mid-run. Safe without extra
+    // coordination: a worker can only be spawned by code running after its
+    // spawner's own bootstrap (and thus this truncation) has completed.
+    fs.writeFileSync(manifestPath, '');
+  }
+
+  const seenHere = new SafeSet();
+  provider[kReadObserver] = (providerPath) => {
+    try {
+      const relative = RegExpPrototypeSymbolReplace(kLeadingSlashRE, providerPath, '');
+      if (relative === '' || seenHere.has(relative)) return;
+      seenHere.add(relative);
+      fs.appendFileSync(manifestPath, relative + '\n');
+    } catch {
+      // Best effort: never let this bookkeeping break the actual read that
+      // triggered it.
+    }
+  };
+}
+
+module.exports = {
+  startCliVfsManifest,
+};

--- a/lib/internal/vfs/file_system.js
+++ b/lib/internal/vfs/file_system.js
@@ -185,6 +185,18 @@ class VirtualFileSystem {
 
   /**
    * Converts an absolute mounted path to a provider-relative POSIX path.
+   * Exposed for callers (such as the module loader's native-addon handling)
+   * that need to reach the underlying provider directly, bypassing this
+   * facade's own fs-shaped methods.
+   * @param {string} inputPath The path to convert
+   * @returns {string}
+   */
+  toProviderPath(inputPath) {
+    return this.#toProviderPath(inputPath);
+  }
+
+  /**
+   * Converts an absolute mounted path to a provider-relative POSIX path.
    * If not mounted, treats the path as already provider-relative.
    * @param {string} inputPath The path to convert
    * @returns {string}

--- a/lib/internal/vfs/provider.js
+++ b/lib/internal/vfs/provider.js
@@ -1,6 +1,10 @@
 'use strict';
 
 const {
+  Symbol,
+} = primordials;
+
+const {
   ERR_METHOD_NOT_IMPLEMENTED,
 } = require('internal/errors').codes;
 
@@ -18,6 +22,17 @@ const {
     COPYFILE_EXCL,
   },
 } = internalBinding('constants');
+
+/**
+ * Internal-only hook: when set on a provider instance (never exposed on the
+ * public node:vfs surface - only internal/vfs/cli_manifest.js pokes this),
+ * readFile()/readFileSync() call it with the provider-relative path of
+ * every file actually read, after the read succeeds. Used by --vfs-manifest
+ * to observe every read regardless of whether it came in through
+ * readFileSync, the promise API, or (since both go through open()+handle
+ * underneath) the module loader itself - without patching any method.
+ */
+const kReadObserver = Symbol('kReadObserver');
 
 /**
  * Base class for VFS providers.
@@ -248,7 +263,9 @@ class VirtualProvider {
       (options.flag ?? 'r') : 'r';
     const handle = await this.open(path, flag);
     try {
-      return await handle.readFile(options);
+      const content = await handle.readFile(options);
+      this[kReadObserver]?.(path);
+      return content;
     } finally {
       await handle.close();
     }
@@ -265,7 +282,9 @@ class VirtualProvider {
       (options.flag ?? 'r') : 'r';
     const handle = this.openSync(path, flag);
     try {
-      return handle.readFileSync(options);
+      const content = handle.readFileSync(options);
+      this[kReadObserver]?.(path);
+      return content;
     } finally {
       handle.closeSync();
     }
@@ -615,4 +634,5 @@ class VirtualProvider {
 
 module.exports = {
   VirtualProvider,
+  kReadObserver,
 };

--- a/lib/internal/vfs/providers/archive.js
+++ b/lib/internal/vfs/providers/archive.js
@@ -1,0 +1,526 @@
+'use strict';
+
+const {
+  ArrayPrototypeIndexOf,
+  ArrayPrototypePush,
+  MathMax,
+  MathMin,
+  StringPrototypeIndexOf,
+  StringPrototypeSlice,
+  StringPrototypeStartsWith,
+} = primordials;
+
+const { Buffer } = require('buffer');
+const {
+  codes: {
+    ERR_INVALID_ARG_TYPE,
+    ERR_METHOD_NOT_IMPLEMENTED,
+  },
+} = require('internal/errors');
+const { VirtualProvider } = require('internal/vfs/provider');
+const { VirtualFileHandle } = require('internal/vfs/file_handle');
+const {
+  createEEXIST,
+  createEISDIR,
+  createENOENT,
+  createENOTDIR,
+  createENOTEMPTY,
+  createEROFS,
+} = require('internal/vfs/errors');
+const { createFileStats, createDirectoryStats } = require('internal/vfs/stats');
+const { Dirent } = require('internal/fs/utils');
+const {
+  fs: { UV_DIRENT_DIR, UV_DIRENT_FILE },
+} = internalBinding('constants');
+const { ZipBuffer, ZipFile } = require('internal/zip');
+
+const EMPTY_BUFFER = Buffer.alloc(0);
+
+function normalize(vfsPath) {
+  return StringPrototypeStartsWith(vfsPath, '/') ? StringPrototypeSlice(vfsPath, 1) : vfsPath;
+}
+
+function isCurrentPosition(position) {
+  return position === null || position === undefined || position === -1;
+}
+
+function isWriteTruncate(flags) {
+  return flags === 'w' || flags === 'w+' || flags === 'wx' || flags === 'wx+';
+}
+
+function isAppend(flags) {
+  return flags === 'a' || flags === 'a+' || flags === 'ax' || flags === 'ax+';
+}
+
+function isReadableFlag(flags) {
+  return flags !== 'w' && flags !== 'a' && flags !== 'wx' && flags !== 'ax';
+}
+
+function isWritableFlag(flags) {
+  return flags !== 'r';
+}
+
+/**
+ * The `options.method` value that reproduces `method` (a `zipEntry.method`
+ * raw compression method number) on `add()`/`addSync()`, so `rename()`
+ * doesn't silently recompress an entry with a different method than the one
+ * it already had (e.g. turning a zstd-compressed entry into a stored one).
+ * @param {number} method
+ * @returns {'store' | 'zstd' | 'deflate'}
+ */
+function methodOption(method) {
+  if (method === 0) return 'store';
+  if (method === 93) return 'zstd';
+  return 'deflate';
+}
+
+/**
+ * A file handle over one ZIP entry. ZIP members can't be edited in place
+ * (they're a single compressed blob), so writes accumulate in memory and are
+ * only committed - as a brand-new entry - when the handle is closed. Since
+ * this is all in-memory buffer manipulation with no real I/O, every method
+ * and its `*Sync` counterpart share one private implementation.
+ */
+class ZipFileHandle extends VirtualFileHandle {
+  #source;
+  #name;
+  #buffer;
+  #size;
+  #dirty = false;
+
+  /**
+   * @param {string} path
+   * @param {string} flags
+   * @param {number} mode
+   * @param {ZipBuffer | ZipFile} source
+   * @param {string} name The archive-relative entry name
+   * @param {Buffer} initial The entry's current decompressed content, or an
+   *   empty buffer for a new/truncated file
+   */
+  constructor(path, flags, mode, source, name, initial) {
+    super(path, flags, mode);
+    this.#source = source;
+    this.#name = name;
+    this.#buffer = initial;
+    this.#size = initial.length;
+    if (isAppend(flags)) this.position = this.#size;
+  }
+
+  #checkReadable() {
+    if (!isReadableFlag(this.flags)) throw createEISDIR('read', this.path);
+  }
+  #checkWritable() {
+    if (!isWritableFlag(this.flags)) throw createEISDIR('write', this.path);
+  }
+  #ensureCapacity(size) {
+    if (size <= this.#buffer.length) return;
+    const capacity = MathMax(size, this.#buffer.length * 2);
+    const grown = Buffer.alloc(capacity);
+    this.#buffer.copy(grown, 0, 0, this.#size);
+    this.#buffer = grown;
+  }
+
+  #doRead(buffer, offset, length, position) {
+    this.#checkReadable();
+    const useCurrent = isCurrentPosition(position);
+    const pos = useCurrent ? this.position : position;
+    const available = MathMax(0, this.#size - pos);
+    const bytesRead = MathMin(length, available);
+    if (bytesRead > 0) this.#buffer.copy(buffer, offset, pos, pos + bytesRead);
+    if (useCurrent) this.position = pos + bytesRead;
+    return { __proto__: null, bytesRead, buffer };
+  }
+  async read(buffer, offset, length, position) {
+    return this.#doRead(buffer, offset, length, position);
+  }
+  readSync(buffer, offset, length, position) {
+    return this.#doRead(buffer, offset, length, position);
+  }
+
+  #doWrite(buffer, offset, length, position) {
+    this.#checkWritable();
+    const useCurrent = isCurrentPosition(position);
+    const pos = isAppend(this.flags) ? this.#size : (useCurrent ? this.position : position);
+    this.#ensureCapacity(pos + length);
+    buffer.copy(this.#buffer, pos, offset, offset + length);
+    if (pos + length > this.#size) this.#size = pos + length;
+    this.#dirty = true;
+    if (useCurrent) this.position = pos + length;
+    return { __proto__: null, bytesWritten: length, buffer };
+  }
+  async write(buffer, offset, length, position) {
+    return this.#doWrite(buffer, offset, length, position);
+  }
+  writeSync(buffer, offset, length, position) {
+    return this.#doWrite(buffer, offset, length, position);
+  }
+
+  #doReadFile(options) {
+    this.#checkReadable();
+    const encoding = typeof options === 'string' ? options : options?.encoding;
+    const content = this.#buffer.subarray(0, this.#size);
+    return encoding && encoding !== 'buffer' ? content.toString(encoding) : Buffer.from(content);
+  }
+  async readFile(options) {
+    return this.#doReadFile(options);
+  }
+  readFileSync(options) {
+    return this.#doReadFile(options);
+  }
+
+  // Replaces content, except in append mode ('a'/'a+'/'ax'/'ax+'), where it
+  // appends to the existing content instead - matching MemoryFileHandle and
+  // what makes `appendFile()`/`appendFileSync()` (built on this, by
+  // VirtualProvider's defaults) actually append.
+  #doWriteFile(data, options) {
+    this.#checkWritable();
+    const content = typeof data === 'string' ? Buffer.from(data, options?.encoding) : Buffer.from(data);
+    if (isAppend(this.flags)) {
+      this.#ensureCapacity(this.#size + content.length);
+      content.copy(this.#buffer, this.#size);
+      this.#size += content.length;
+    } else {
+      this.#buffer = content;
+      this.#size = content.length;
+    }
+    this.#dirty = true;
+  }
+  async writeFile(data, options) {
+    this.#doWriteFile(data, options);
+  }
+  writeFileSync(data, options) {
+    this.#doWriteFile(data, options);
+  }
+
+  #doStat() {
+    return createFileStats(this.#size, { mode: this.mode });
+  }
+  async stat(options) {
+    return this.#doStat();
+  }
+  statSync(options) {
+    return this.#doStat();
+  }
+
+  #doTruncate(len) {
+    this.#checkWritable();
+    this.#ensureCapacity(len);
+    this.#size = len;
+    this.#dirty = true;
+  }
+  async truncate(len = 0) {
+    this.#doTruncate(len);
+  }
+  truncateSync(len = 0) {
+    this.#doTruncate(len);
+  }
+
+  async close() {
+    if (this.#dirty && isWritableFlag(this.flags)) {
+      await this.#source.add(this.#name, this.#buffer.subarray(0, this.#size), { mode: this.mode });
+    }
+    await super.close();
+  }
+  closeSync() {
+    if (this.#dirty && isWritableFlag(this.flags)) {
+      this.#source.addSync(this.#name, this.#buffer.subarray(0, this.#size), { mode: this.mode });
+    }
+    super.closeSync();
+  }
+}
+
+/**
+ * A `node:vfs` provider backed by a ZIP archive: either a [`ZipBuffer`][] (in
+ * memory) or a [`ZipFile`][] (on disk). Read-only unless the underlying
+ * archive is writable (a `ZipBuffer`, or a `ZipFile` opened with
+ * `{ writable: true }`). Every method has a synchronous counterpart, backed
+ * by the equally complete synchronous surface `ZipBuffer`/`ZipFile` expose;
+ * as with those, the synchronous methods here block the Node.js event loop
+ * and further JavaScript execution until the operation (including any
+ * deflate/inflate pass) completes.
+ */
+class ZipProvider extends VirtualProvider {
+  #source;
+
+  /**
+   * @param {ZipBuffer | ZipFile} source
+   */
+  constructor(source) {
+    super();
+    if (!(source instanceof ZipBuffer) && !(source instanceof ZipFile)) {
+      throw new ERR_INVALID_ARG_TYPE('source', ['ZipBuffer', 'ZipFile'], source);
+    }
+    this.#source = source;
+  }
+
+  get readonly() { return !this.#source.writable; }
+
+  /**
+   * @param {string} name
+   * @returns {Promise<import('internal/zip').ZipEntry | null>}
+   */
+  async #getEntry(name) {
+    return this.#source.has(name) ? this.#source.get(name) : null;
+  }
+  /**
+   * @param {string} name
+   * @returns {import('internal/zip').ZipEntry | null}
+   */
+  #getEntrySync(name) {
+    if (!this.#source.has(name)) return null;
+    // `ZipBuffer.prototype.get` is already synchronous (it has no `getSync`
+    // of its own); `ZipFile.prototype.get` is asynchronous, so its `getSync`
+    // is used instead when present.
+    return typeof this.#source.getSync === 'function' ?
+      this.#source.getSync(name) : this.#source.get(name);
+  }
+  /**
+   * @param {string} name
+   * @returns {boolean}
+   */
+  #deleteEntrySync(name) {
+    // Same reasoning as `#getEntrySync`: `ZipBuffer.prototype.delete` is
+    // already synchronous; `ZipFile.prototype.delete` is not, so its
+    // `deleteSync` is used instead when present.
+    return typeof this.#source.deleteSync === 'function' ?
+      this.#source.deleteSync(name) : this.#source.delete(name);
+  }
+
+  /**
+   * Whether `name` (no trailing slash) is a directory: either explicitly
+   * (a `"name/"` entry) or implicitly (some entry starts with `"name/"`).
+   * @param {string} name
+   * @returns {boolean}
+   */
+  #isDirectory(name) {
+    const prefix = `${name}/`;
+    if (this.#source.has(prefix)) return true;
+    for (const key of this.#source.keys()) {
+      if (StringPrototypeStartsWith(key, prefix)) return true;
+    }
+    return false;
+  }
+
+  async open(path, flags, mode) {
+    const name = normalize(path);
+    const fileEntry = await this.#getEntry(name);
+    if (fileEntry === null && this.#isDirectory(name)) {
+      throw createEISDIR('open', path);
+    }
+    const exists = fileEntry !== null;
+    if ((isWriteTruncate(flags) || isAppend(flags)) && this.readonly) {
+      throw createEROFS('open', path);
+    }
+    if ((flags === 'wx' || flags === 'wx+' || flags === 'ax' || flags === 'ax+') && exists) {
+      throw createEEXIST('open', path);
+    }
+    if (!exists && (flags === 'r' || flags === 'r+')) {
+      throw createENOENT('open', path);
+    }
+    let initial = EMPTY_BUFFER;
+    if (exists && !isWriteTruncate(flags)) {
+      initial = await fileEntry.content();
+    }
+    return new ZipFileHandle(path, flags, mode, this.#source, name, initial);
+  }
+  openSync(path, flags, mode) {
+    const name = normalize(path);
+    const fileEntry = this.#getEntrySync(name);
+    if (fileEntry === null && this.#isDirectory(name)) {
+      throw createEISDIR('open', path);
+    }
+    const exists = fileEntry !== null;
+    if ((isWriteTruncate(flags) || isAppend(flags)) && this.readonly) {
+      throw createEROFS('open', path);
+    }
+    if ((flags === 'wx' || flags === 'wx+' || flags === 'ax' || flags === 'ax+') && exists) {
+      throw createEEXIST('open', path);
+    }
+    if (!exists && (flags === 'r' || flags === 'r+')) {
+      throw createENOENT('open', path);
+    }
+    let initial = EMPTY_BUFFER;
+    if (exists && !isWriteTruncate(flags)) {
+      initial = fileEntry.contentSync();
+    }
+    return new ZipFileHandle(path, flags, mode, this.#source, name, initial);
+  }
+
+  async stat(path, options) {
+    const name = normalize(path);
+    if (name === '') return createDirectoryStats({ mode: 0o755 });
+    const entry = await this.#getEntry(name) ?? await this.#getEntry(`${name}/`);
+    if (entry !== null) {
+      return entry.isDirectory ?
+        createDirectoryStats({ mode: entry.mode || 0o755, mtimeMs: entry.modified.getTime() }) :
+        createFileStats(entry.size, { mode: entry.mode || 0o644, mtimeMs: entry.modified.getTime() });
+    }
+    if (this.#isDirectory(name)) return createDirectoryStats({ mode: 0o755 });
+    throw createENOENT('stat', path);
+  }
+  statSync(path, options) {
+    const name = normalize(path);
+    if (name === '') return createDirectoryStats({ mode: 0o755 });
+    const entry = this.#getEntrySync(name) ?? this.#getEntrySync(`${name}/`);
+    if (entry !== null) {
+      return entry.isDirectory ?
+        createDirectoryStats({ mode: entry.mode || 0o755, mtimeMs: entry.modified.getTime() }) :
+        createFileStats(entry.size, { mode: entry.mode || 0o644, mtimeMs: entry.modified.getTime() });
+    }
+    if (this.#isDirectory(name)) return createDirectoryStats({ mode: 0o755 });
+    throw createENOENT('stat', path);
+  }
+
+  #readdirEntries(path, name, options, stats) {
+    if (!stats.isDirectory()) throw createENOTDIR('scandir', path);
+    const prefix = name === '' ? '' : `${name}/`;
+    const withFileTypes = options?.withFileTypes === true;
+    const names = [];
+    const isDir = [];
+    for (const key of this.#source.keys()) {
+      if (!StringPrototypeStartsWith(key, prefix)) continue;
+      const rest = StringPrototypeSlice(key, prefix.length);
+      if (rest === '') continue; // The directory's own explicit entry
+      const slash = StringPrototypeIndexOf(rest, '/');
+      const childName = slash === -1 ? rest : StringPrototypeSlice(rest, 0, slash);
+      const childIsDir = slash !== -1;
+      const existingIndex = ArrayPrototypeIndexOf(names, childName);
+      if (existingIndex !== -1) {
+        if (childIsDir) isDir[existingIndex] = true;
+        continue;
+      }
+      ArrayPrototypePush(names, childName);
+      ArrayPrototypePush(isDir, childIsDir);
+    }
+    const result = [];
+    for (let i = 0; i < names.length; i++) {
+      if (withFileTypes) {
+        ArrayPrototypePush(result, new Dirent(names[i], isDir[i] ? UV_DIRENT_DIR : UV_DIRENT_FILE, name));
+      } else {
+        ArrayPrototypePush(result, names[i]);
+      }
+    }
+    return result;
+  }
+  async readdir(path, options) {
+    if (options?.recursive) {
+      throw new ERR_METHOD_NOT_IMPLEMENTED("readdir with { recursive: true } on an 'archive' provider");
+    }
+    const name = normalize(path);
+    return this.#readdirEntries(path, name, options, await this.stat(path));
+  }
+  readdirSync(path, options) {
+    if (options?.recursive) {
+      throw new ERR_METHOD_NOT_IMPLEMENTED("readdirSync with { recursive: true } on an 'archive' provider");
+    }
+    const name = normalize(path);
+    return this.#readdirEntries(path, name, options, this.statSync(path));
+  }
+
+  async mkdir(path, options) {
+    if (this.readonly) throw createEROFS('mkdir', path);
+    const name = normalize(path);
+    if (await this.exists(path)) {
+      if (options?.recursive) return undefined;
+      throw createEEXIST('mkdir', path);
+    }
+    await this.#source.add(`${name}/`, EMPTY_BUFFER, { mode: options?.mode });
+    return undefined;
+  }
+  mkdirSync(path, options) {
+    if (this.readonly) throw createEROFS('mkdir', path);
+    const name = normalize(path);
+    if (this.existsSync(path)) {
+      if (options?.recursive) return undefined;
+      throw createEEXIST('mkdir', path);
+    }
+    this.#source.addSync(`${name}/`, EMPTY_BUFFER, { mode: options?.mode });
+    return undefined;
+  }
+
+  async rmdir(path) {
+    if (this.readonly) throw createEROFS('rmdir', path);
+    const name = normalize(path);
+    const stats = await this.stat(path);
+    if (!stats.isDirectory()) throw createENOTDIR('rmdir', path);
+    const prefix = `${name}/`;
+    for (const key of this.#source.keys()) {
+      if (key !== prefix && StringPrototypeStartsWith(key, prefix)) {
+        throw createENOTEMPTY('rmdir', path);
+      }
+    }
+    if (!this.#source.has(prefix)) {
+      // An implicit-only directory can never be empty (something has to be
+      // under it for it to exist at all), so getting here means `path` is
+      // not a directory this provider can remove.
+      throw createENOENT('rmdir', path);
+    }
+    await this.#source.delete(prefix);
+  }
+  rmdirSync(path) {
+    if (this.readonly) throw createEROFS('rmdir', path);
+    const name = normalize(path);
+    const stats = this.statSync(path);
+    if (!stats.isDirectory()) throw createENOTDIR('rmdir', path);
+    const prefix = `${name}/`;
+    for (const key of this.#source.keys()) {
+      if (key !== prefix && StringPrototypeStartsWith(key, prefix)) {
+        throw createENOTEMPTY('rmdir', path);
+      }
+    }
+    if (!this.#source.has(prefix)) {
+      throw createENOENT('rmdir', path);
+    }
+    this.#deleteEntrySync(prefix);
+  }
+
+  async unlink(path) {
+    if (this.readonly) throw createEROFS('unlink', path);
+    const name = normalize(path);
+    if (!this.#source.has(name)) {
+      throw this.#isDirectory(name) ? createEISDIR('unlink', path) : createENOENT('unlink', path);
+    }
+    await this.#source.delete(name);
+  }
+  unlinkSync(path) {
+    if (this.readonly) throw createEROFS('unlink', path);
+    const name = normalize(path);
+    if (!this.#source.has(name)) {
+      throw this.#isDirectory(name) ? createEISDIR('unlink', path) : createENOENT('unlink', path);
+    }
+    this.#deleteEntrySync(name);
+  }
+
+  async rename(oldPath, newPath) {
+    if (this.readonly) throw createEROFS('rename', oldPath);
+    const oldName = normalize(oldPath);
+    const newName = normalize(newPath);
+    const entry = await this.#getEntry(oldName);
+    if (entry === null) throw createENOENT('rename', oldPath);
+    const content = await entry.content();
+    await this.#source.add(newName, content, {
+      mode: entry.mode || undefined,
+      modified: entry.modified,
+      method: methodOption(entry.method),
+    });
+    await this.#source.delete(oldName);
+  }
+  renameSync(oldPath, newPath) {
+    if (this.readonly) throw createEROFS('rename', oldPath);
+    const oldName = normalize(oldPath);
+    const newName = normalize(newPath);
+    const entry = this.#getEntrySync(oldName);
+    if (entry === null) throw createENOENT('rename', oldPath);
+    const content = entry.contentSync();
+    this.#source.addSync(newName, content, {
+      mode: entry.mode || undefined,
+      modified: entry.modified,
+      method: methodOption(entry.method),
+    });
+    this.#deleteEntrySync(oldName);
+  }
+}
+
+module.exports = {
+  ZipProvider,
+};

--- a/lib/internal/vfs/providers/real.js
+++ b/lib/internal/vfs/providers/real.js
@@ -11,7 +11,7 @@ const fs = require('fs');
 const path = require('path');
 const { VirtualProvider } = require('internal/vfs/provider');
 const { VirtualFileHandle } = require('internal/vfs/file_handle');
-const { getValidatedPath } = require('internal/fs/utils');
+const { getValidatedPath, vfsState } = require('internal/fs/utils');
 const { setOwnProperty } = require('internal/util');
 const {
   createEACCES,
@@ -20,6 +20,29 @@ const {
 } = require('internal/vfs/errors');
 
 const kReadFileUnknownBufferLength = 8192;
+
+/**
+ * Runs `fn` with the global VFS mount hooks (internal/fs/utils's vfsState)
+ * temporarily disabled. RealFSProvider's own path-based `fs.*` calls must
+ * never go through that hook: if this provider's own rootPath happens to
+ * fall under an active VFS mount - notably its own, when mounted at its own
+ * rootPath, as node --vfs=<directory> does - the hook would redirect the
+ * provider's real I/O straight back into itself, recursing forever.
+ * Fd-based calls (RealFileHandle's read/write/fstat/...) are unaffected by
+ * the hook to begin with, since it keys those off virtual fds specifically,
+ * so they don't need this.
+ * @param {Function} fn
+ * @returns {any}
+ */
+function withoutVfsInterception(fn) {
+  const saved = vfsState.handlers;
+  vfsState.handlers = null;
+  try {
+    return fn();
+  } finally {
+    vfsState.handlers = saved;
+  }
+}
 
 /**
  * A file handle that wraps a real file descriptor.
@@ -172,12 +195,12 @@ class RealFileHandle extends VirtualFileHandle {
 
   writeFileSync(data, options) {
     this.#checkClosed('write');
-    fs.writeFileSync(this.#realPath, data, options);
+    withoutVfsInterception(() => fs.writeFileSync(this.#realPath, data, options));
   }
 
   async writeFile(data, options) {
     this.#checkClosed('write');
-    return fs.promises.writeFile(this.#realPath, data, options);
+    return withoutVfsInterception(() => fs.promises.writeFile(this.#realPath, data, options));
   }
 
   statSync(options) {
@@ -259,6 +282,18 @@ class RealFSProvider extends VirtualProvider {
   }
 
   /**
+   * Resolves a VFS-relative path to its real underlying filesystem path,
+   * applying the same root-containment checks as every other method here,
+   * without opening it. Used by the module loader to `dlopen()` a native
+   * addon directly from its real location instead of extracting it.
+   * @param {string} vfsPath
+   * @returns {string}
+   */
+  toRealPath(vfsPath) {
+    return withoutVfsInterception(() => this.#resolvePath(vfsPath));
+  }
+
+  /**
    * Resolves a VFS path to a real filesystem path.
    * Ensures the path doesn't escape the root directory.
    * @param {string} vfsPath The VFS path (relative to provider root)
@@ -330,112 +365,148 @@ class RealFSProvider extends VirtualProvider {
   }
 
   openSync(vfsPath, flags, mode) {
-    const realPath = this.#resolvePath(vfsPath);
-    const fd = fs.openSync(realPath, flags, mode);
-    return new RealFileHandle(vfsPath, flags, mode ?? 0o644, fd, realPath);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      const fd = fs.openSync(realPath, flags, mode);
+      return new RealFileHandle(vfsPath, flags, mode ?? 0o644, fd, realPath);
+    });
   }
 
   async open(vfsPath, flags, mode) {
-    const realPath = this.#resolvePath(vfsPath);
-    return new Promise((resolve, reject) => {
-      fs.open(realPath, flags, mode, (err, fd) => {
-        if (err) reject(err);
-        else resolve(new RealFileHandle(vfsPath, flags, mode ?? 0o644, fd, realPath));
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return new Promise((resolve, reject) => {
+        fs.open(realPath, flags, mode, (err, fd) => {
+          if (err) reject(err);
+          else resolve(new RealFileHandle(vfsPath, flags, mode ?? 0o644, fd, realPath));
+        });
       });
     });
   }
 
   statSync(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.statSync(realPath, options);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.statSync(realPath, options);
+    });
   }
 
   async stat(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.promises.stat(realPath, options);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.promises.stat(realPath, options);
+    });
   }
 
   lstatSync(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath, false);
-    return fs.lstatSync(realPath, options);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath, false);
+      return fs.lstatSync(realPath, options);
+    });
   }
 
   async lstat(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath, false);
-    return fs.promises.lstat(realPath, options);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath, false);
+      return fs.promises.lstat(realPath, options);
+    });
   }
 
   readdirSync(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.readdirSync(realPath, options);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.readdirSync(realPath, options);
+    });
   }
 
   async readdir(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.promises.readdir(realPath, options);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.promises.readdir(realPath, options);
+    });
   }
 
   mkdirSync(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.mkdirSync(realPath, options);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.mkdirSync(realPath, options);
+    });
   }
 
   async mkdir(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.promises.mkdir(realPath, options);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.promises.mkdir(realPath, options);
+    });
   }
 
   rmdirSync(vfsPath) {
-    const realPath = this.#resolvePath(vfsPath);
-    fs.rmdirSync(realPath);
+    withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      fs.rmdirSync(realPath);
+    });
   }
 
   async rmdir(vfsPath) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.promises.rmdir(realPath);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.promises.rmdir(realPath);
+    });
   }
 
   unlinkSync(vfsPath) {
-    const realPath = this.#resolvePath(vfsPath);
-    fs.unlinkSync(realPath);
+    withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      fs.unlinkSync(realPath);
+    });
   }
 
   async unlink(vfsPath) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.promises.unlink(realPath);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.promises.unlink(realPath);
+    });
   }
 
   renameSync(oldVfsPath, newVfsPath) {
-    const oldRealPath = this.#resolvePath(oldVfsPath);
-    const newRealPath = this.#resolvePath(newVfsPath);
-    fs.renameSync(oldRealPath, newRealPath);
+    withoutVfsInterception(() => {
+      const oldRealPath = this.#resolvePath(oldVfsPath);
+      const newRealPath = this.#resolvePath(newVfsPath);
+      fs.renameSync(oldRealPath, newRealPath);
+    });
   }
 
   async rename(oldVfsPath, newVfsPath) {
-    const oldRealPath = this.#resolvePath(oldVfsPath);
-    const newRealPath = this.#resolvePath(newVfsPath);
-    return fs.promises.rename(oldRealPath, newRealPath);
+    return withoutVfsInterception(() => {
+      const oldRealPath = this.#resolvePath(oldVfsPath);
+      const newRealPath = this.#resolvePath(newVfsPath);
+      return fs.promises.rename(oldRealPath, newRealPath);
+    });
   }
 
   readlinkSync(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath, false);
-    const target = fs.readlinkSync(realPath, options);
-    // Translate absolute targets within rootPath to VFS-relative
-    if (path.isAbsolute(target)) {
-      const rootWithSep = this.#rootPath + path.sep;
-      if (target === this.#rootPath) {
-        return '/';
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath, false);
+      const target = fs.readlinkSync(realPath, options);
+      // Translate absolute targets within rootPath to VFS-relative
+      if (path.isAbsolute(target)) {
+        const rootWithSep = this.#rootPath + path.sep;
+        if (target === this.#rootPath) {
+          return '/';
+        }
+        if (StringPrototypeStartsWith(target, rootWithSep)) {
+          return '/' + target.slice(rootWithSep.length).replace(/\\/g, '/');
+        }
       }
-      if (StringPrototypeStartsWith(target, rootWithSep)) {
-        return '/' + target.slice(rootWithSep.length).replace(/\\/g, '/');
-      }
-    }
-    return target;
+      return target;
+    });
   }
 
   async readlink(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath, false);
-    const target = await fs.promises.readlink(realPath, options);
+    const target = await withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath, false);
+      return fs.promises.readlink(realPath, options);
+    });
     // Translate absolute targets within rootPath to VFS-relative
     if (path.isAbsolute(target)) {
       const rootWithSep = this.#rootPath + path.sep;
@@ -454,15 +525,17 @@ class RealFSProvider extends VirtualProvider {
     if (path.isAbsolute(target)) {
       throw createEACCES('symlink', vfsPath);
     }
-    const realPath = this.#resolvePath(vfsPath);
-    const resolvedTarget = path.resolve(path.dirname(realPath), target);
-    const rootWithSep = this.#rootPath.endsWith(path.sep) ?
-      this.#rootPath : this.#rootPath + path.sep;
-    if (resolvedTarget !== this.#rootPath &&
-        !StringPrototypeStartsWith(resolvedTarget, rootWithSep)) {
-      throw createEACCES('symlink', vfsPath);
-    }
-    fs.symlinkSync(target, realPath, type);
+    withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      const resolvedTarget = path.resolve(path.dirname(realPath), target);
+      const rootWithSep = this.#rootPath.endsWith(path.sep) ?
+        this.#rootPath : this.#rootPath + path.sep;
+      if (resolvedTarget !== this.#rootPath &&
+          !StringPrototypeStartsWith(resolvedTarget, rootWithSep)) {
+        throw createEACCES('symlink', vfsPath);
+      }
+      fs.symlinkSync(target, realPath, type);
+    });
   }
 
   async symlink(target, vfsPath, type) {
@@ -470,15 +543,17 @@ class RealFSProvider extends VirtualProvider {
     if (path.isAbsolute(target)) {
       throw createEACCES('symlink', vfsPath);
     }
-    const realPath = this.#resolvePath(vfsPath);
-    const resolvedTarget = path.resolve(path.dirname(realPath), target);
-    const rootWithSep = this.#rootPath.endsWith(path.sep) ?
-      this.#rootPath : this.#rootPath + path.sep;
-    if (resolvedTarget !== this.#rootPath &&
-        !StringPrototypeStartsWith(resolvedTarget, rootWithSep)) {
-      throw createEACCES('symlink', vfsPath);
-    }
-    return fs.promises.symlink(target, realPath, type);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      const resolvedTarget = path.resolve(path.dirname(realPath), target);
+      const rootWithSep = this.#rootPath.endsWith(path.sep) ?
+        this.#rootPath : this.#rootPath + path.sep;
+      if (resolvedTarget !== this.#rootPath &&
+          !StringPrototypeStartsWith(resolvedTarget, rootWithSep)) {
+        throw createEACCES('symlink', vfsPath);
+      }
+      return fs.promises.symlink(target, realPath, type);
+    });
   }
 
   // path.relative handles case-insensitivity on Windows, which matters here
@@ -496,37 +571,49 @@ class RealFSProvider extends VirtualProvider {
   }
 
   realpathSync(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    const resolved = fs.realpathSync(realPath, options);
-    return this.#resolvedToVfsPath(resolved, vfsPath, 'realpath');
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      const resolved = fs.realpathSync(realPath, options);
+      return this.#resolvedToVfsPath(resolved, vfsPath, 'realpath');
+    });
   }
 
   async realpath(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    const resolved = await fs.promises.realpath(realPath, options);
+    const resolved = await withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.promises.realpath(realPath, options);
+    });
     return this.#resolvedToVfsPath(resolved, vfsPath, 'realpath');
   }
 
   accessSync(vfsPath, mode) {
-    const realPath = this.#resolvePath(vfsPath);
-    fs.accessSync(realPath, mode);
+    withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      fs.accessSync(realPath, mode);
+    });
   }
 
   async access(vfsPath, mode) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.promises.access(realPath, mode);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.promises.access(realPath, mode);
+    });
   }
 
   copyFileSync(srcVfsPath, destVfsPath, mode) {
-    const srcRealPath = this.#resolvePath(srcVfsPath);
-    const destRealPath = this.#resolvePath(destVfsPath);
-    fs.copyFileSync(srcRealPath, destRealPath, mode);
+    withoutVfsInterception(() => {
+      const srcRealPath = this.#resolvePath(srcVfsPath);
+      const destRealPath = this.#resolvePath(destVfsPath);
+      fs.copyFileSync(srcRealPath, destRealPath, mode);
+    });
   }
 
   async copyFile(srcVfsPath, destVfsPath, mode) {
-    const srcRealPath = this.#resolvePath(srcVfsPath);
-    const destRealPath = this.#resolvePath(destVfsPath);
-    return fs.promises.copyFile(srcRealPath, destRealPath, mode);
+    return withoutVfsInterception(() => {
+      const srcRealPath = this.#resolvePath(srcVfsPath);
+      const destRealPath = this.#resolvePath(destVfsPath);
+      return fs.promises.copyFile(srcRealPath, destRealPath, mode);
+    });
   }
 
   get supportsWatch() {
@@ -534,23 +621,31 @@ class RealFSProvider extends VirtualProvider {
   }
 
   watch(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.watch(realPath, options);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.watch(realPath, options);
+    });
   }
 
   watchAsync(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.promises.watch(realPath, options);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.promises.watch(realPath, options);
+    });
   }
 
   watchFile(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.watchFile(realPath, options, () => {});
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.watchFile(realPath, options, () => {});
+    });
   }
 
   unwatchFile(vfsPath, listener) {
-    const realPath = this.#resolvePath(vfsPath);
-    fs.unwatchFile(realPath, listener);
+    withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      fs.unwatchFile(realPath, listener);
+    });
   }
 }
 

--- a/lib/internal/vfs/setup.js
+++ b/lib/internal/vfs/setup.js
@@ -688,4 +688,5 @@ function createVfsHandlers() {
 module.exports = {
   registerVFS,
   deregisterVFS,
+  findVFSForPath,
 };

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -5,6 +5,9 @@ const {
   ArrayPrototypeForEach,
   ArrayPrototypeMap,
   ArrayPrototypePush,
+  ArrayPrototypePushApply,
+  ArrayPrototypeSlice,
+  ArrayPrototypeSome,
   AtomicsAdd,
   Float64Array,
   FunctionPrototypeBind,
@@ -19,6 +22,7 @@ const {
   SafeArrayIterator,
   SafeMap,
   String,
+  StringPrototypeStartsWith,
   StringPrototypeTrim,
   Symbol,
   SymbolAsyncDispose,
@@ -30,6 +34,7 @@ const {
 const EventEmitter = require('events');
 const assert = require('internal/assert');
 const path = require('path');
+const { getOptionValue } = require('internal/options');
 const {
   internalEventLoopUtilization,
 } = require('internal/perf/event_loop_utilization');
@@ -203,6 +208,37 @@ class HeapProfileHandle {
   }
 }
 
+/**
+ * A Worker constructed without an explicit `execArgv` already inherits the
+ * parent's whole per-isolate options (including --vfs/--vfs-manifest) via
+ * the native Clone()-on-no-explicit-execArgv path. But one constructed with
+ * an explicit `execArgv` gets a fresh, from-scratch options parse instead -
+ * so without this, code running under a --vfs mount could spawn an
+ * "escaped" worker simply by passing its own execArgv. Force the active
+ * flags along unless the caller already specified their own.
+ * @param {Array<string>} execArgv
+ * @returns {Array<string>}
+ */
+function withInheritedVfsFlags(execArgv) {
+  const toInject = [];
+
+  const vfsTarget = getOptionValue('--vfs');
+  if (vfsTarget && !ArrayPrototypeSome(execArgv, (arg) => StringPrototypeStartsWith(arg, '--vfs='))) {
+    ArrayPrototypePush(toInject, `--vfs=${vfsTarget}`);
+  }
+
+  const vfsManifest = getOptionValue('--vfs-manifest');
+  if (vfsManifest &&
+      !ArrayPrototypeSome(execArgv, (arg) => StringPrototypeStartsWith(arg, '--vfs-manifest='))) {
+    ArrayPrototypePush(toInject, `--vfs-manifest=${vfsManifest}`);
+  }
+
+  if (toInject.length === 0) return execArgv;
+  const result = ArrayPrototypeSlice(execArgv);
+  ArrayPrototypePushApply(result, toInject);
+  return result;
+}
+
 class Worker extends EventEmitter {
   constructor(filename, options = kEmptyObject) {
     throwIfBuildingSnapshot('Creating workers');
@@ -214,8 +250,11 @@ class Worker extends EventEmitter {
       options,
       `isInternal: ${isInternal}`,
     );
-    if (options.execArgv)
-      validateArray(options.execArgv, 'options.execArgv');
+    let execArgv = options.execArgv;
+    if (execArgv) {
+      validateArray(execArgv, 'options.execArgv');
+      execArgv = withInheritedVfsFlags(execArgv);
+    }
 
     let argv;
     if (options.argv) {
@@ -287,7 +326,7 @@ class Worker extends EventEmitter {
     // Set up the C++ handle for the worker, as well as some internal wiring.
     this[kHandle] = new WorkerImpl(url,
                                    env === process.env ? null : env,
-                                   options.execArgv,
+                                   execArgv,
                                    parseResourceLimits(options.resourceLimits),
                                    !!(options.trackUnmanagedFds ?? true),
                                    isInternal,

--- a/lib/vfs.js
+++ b/lib/vfs.js
@@ -8,6 +8,7 @@ const { VirtualFileSystem } = require('internal/vfs/file_system');
 const { VirtualProvider } = require('internal/vfs/provider');
 const { MemoryProvider } = require('internal/vfs/providers/memory');
 const { RealFSProvider } = require('internal/vfs/providers/real');
+const { ZipProvider } = require('internal/vfs/providers/archive');
 
 /**
  * Creates a new VirtualFileSystem instance.
@@ -34,4 +35,5 @@ module.exports = {
   VirtualProvider,
   MemoryProvider,
   RealFSProvider,
+  ZipProvider,
 };

--- a/src/node.cc
+++ b/src/node.cc
@@ -389,7 +389,12 @@ MaybeLocal<Value> StartExecution(Environment* env,
     return StartExecution(env, "internal/main/watch_mode");
   }
 
-  if (!first_argv.empty() && first_argv != "-") {
+  // An active --vfs mount is itself an entry point: with no positional
+  // argument, argv[1] defaults to the mount root and its package.json
+  // "main"/index.js decides what runs (see patchProcessObject()), so route
+  // to run_main_module rather than falling through to the REPL/stdin.
+  if ((!first_argv.empty() && first_argv != "-") ||
+      !env->options()->vfs.empty()) {
     return StartExecution(env, "internal/main/run_main_module");
   }
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -623,6 +623,18 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "experimental node:vfs module",
             &EnvironmentOptions::experimental_vfs,
             kAllowedInEnvvar);
+  AddOption("--vfs",
+            "run the entry point and all module resolution against a "
+            "virtual file system mounted from the given directory or ZIP "
+            "archive",
+            &EnvironmentOptions::vfs,
+            kAllowedInEnvvar);
+  AddOption("--vfs-manifest",
+            "used with a directory --vfs target: append the path of every "
+            "file actually read through the mount during this run to the "
+            "given file, one per line",
+            &EnvironmentOptions::vfs_manifest,
+            kAllowedInEnvvar);
   AddOption("--experimental-quic",
 #ifndef OPENSSL_NO_QUIC
             "experimental QUIC support",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -133,6 +133,8 @@ class EnvironmentOptions : public Options {
   bool experimental_sqlite = HAVE_SQLITE;
   bool experimental_stream_iter = EXPERIMENTALS_DEFAULT_VALUE;
   bool experimental_vfs = EXPERIMENTALS_DEFAULT_VALUE;
+  std::string vfs;
+  std::string vfs_manifest;
   bool webstorage = HAVE_SQLITE;
   bool experimental_dtls = EXPERIMENTALS_DEFAULT_VALUE;
   bool experimental_quic = EXPERIMENTALS_DEFAULT_VALUE;

--- a/test/parallel/test-vfs-cli-flag-addons.js
+++ b/test/parallel/test-vfs-cli-flag-addons.js
@@ -1,0 +1,80 @@
+// Flags: --expose-internals
+'use strict';
+
+// Unit-tests internal/modules/vfs_addons's resolveAddonRealPath() directly
+// (rather than through an actual compiled native addon + --vfs child
+// process, which this environment can't build): a directory-backed mount
+// should resolve straight to the real underlying file, no copying; an
+// archive-backed mount should extract to a content-hashed real temp file,
+// reusing it on a repeated resolve of the same content.
+
+const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+}
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const zlib = require('zlib');
+
+const { VirtualFileSystem } = require('internal/vfs/file_system');
+const { RealFSProvider } = require('internal/vfs/providers/real');
+const { ZipProvider } = require('internal/vfs/providers/archive');
+const { resolveAddonRealPath } = require('internal/modules/vfs_addons');
+
+tmpdir.refresh();
+
+// -- directory-backed: returns the real underlying path, no extraction ----
+
+{
+  const dir = path.join(tmpdir.path, 'dir-mount');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'addon.node'), 'fake addon bytes');
+
+  const provider = new RealFSProvider(dir);
+  const vfs = new VirtualFileSystem(provider, { emitExperimentalWarning: false });
+  vfs.mount(dir);
+
+  const vfsPath = path.join(dir, 'addon.node');
+  const realPath = resolveAddonRealPath(vfsPath);
+  assert.strictEqual(realPath, path.join(dir, 'addon.node'));
+  assert.strictEqual(fs.readFileSync(realPath, 'utf8'), 'fake addon bytes');
+
+  // A path outside the mount is left for the caller to handle unchanged.
+  assert.strictEqual(resolveAddonRealPath(path.join(tmpdir.path, 'elsewhere.node')), null);
+
+  vfs.unmount();
+}
+
+// -- archive-backed: extracts to a content-hashed temp file ----------------
+
+(async () => {
+  const dir = path.join(tmpdir.path, 'zip-mount');
+  fs.mkdirSync(dir, { recursive: true });
+  const zipPath = path.join(dir, 'app.zip');
+  const content = Buffer.from('fake addon bytes from zip');
+  const entry = await zlib.ZipEntry.create('addon.node', content, { method: 'store' });
+  const chunks = [];
+  for await (const chunk of zlib.createZipArchive([entry])) chunks.push(chunk);
+  fs.writeFileSync(zipPath, Buffer.concat(chunks));
+
+  const zipFile = await zlib.ZipFile.open(zipPath);
+  const provider = new ZipProvider(zipFile);
+  const vfs = new VirtualFileSystem(provider, { emitExperimentalWarning: false });
+  vfs.mount(zipPath);
+
+  const vfsPath = path.join(zipPath, 'addon.node');
+  const realPath = resolveAddonRealPath(vfsPath);
+
+  const expectedHash = crypto.createHash('sha256').update(content).digest('hex');
+  assert.strictEqual(path.basename(realPath), `${expectedHash}.node`);
+  assert.strictEqual(fs.readFileSync(realPath, 'utf8'), 'fake addon bytes from zip');
+
+  // Resolving the same content again reuses the same extracted file.
+  assert.strictEqual(resolveAddonRealPath(vfsPath), realPath);
+
+  vfs.unmount();
+  await zipFile.close();
+})().then(common.mustCall());

--- a/test/parallel/test-vfs-cli-flag.js
+++ b/test/parallel/test-vfs-cli-flag.js
@@ -1,0 +1,192 @@
+'use strict';
+
+// Exercises the --vfs=<target> startup flag end to end, by actually
+// spawning `node --vfs=<fixture>` against small CJS/ESM fixture trees and
+// ZIP archives built at test time: entry-point resolution, package.json
+// "type"/main-field/node_modules resolution happening entirely inside the
+// mount, the mount being scoped to its own target (not the whole real
+// filesystem), worker_threads inheriting the mount, and a clear error for
+// an invalid target.
+//
+// With --vfs active, argv[1] is unconditionally the mount root - as with
+// `node <dir>` - so fixtures run via their own index.js / package.json
+// "main", and any positional arguments are the app's own (argv[2] onward),
+// never an entry-file override.
+
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const zlib = require('zlib');
+const { spawnSync } = require('child_process');
+
+tmpdir.refresh();
+let fixtureId = 0;
+function nextDir(name) {
+  const dir = path.join(tmpdir.path, `${fixtureId++}-${name}`);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeTree(dir, files) {
+  for (const { 0: name, 1: content } of Object.entries(files)) {
+    const filePath = path.join(dir, name);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content);
+  }
+}
+
+async function zipFromTree(files, dest) {
+  const entries = [];
+  for (const { 0: name, 1: content } of Object.entries(files)) {
+    entries.push(await zlib.ZipEntry.create(name, Buffer.from(content)));
+  }
+  const chunks = [];
+  for await (const chunk of zlib.createZipArchive(entries)) chunks.push(chunk);
+  fs.writeFileSync(dest, Buffer.concat(chunks));
+}
+
+function runVfs(target, extraArgs = []) {
+  return spawnSync(process.execPath, [`--vfs=${target}`, ...extraArgs], {
+    encoding: 'utf8',
+  });
+}
+
+(async () => {
+  // -- Basic CJS entry: directory-backed and archive-backed -----------------
+  //
+  // No entry-file argument is ever passed: with --vfs active, argv[1] is
+  // unconditionally the mount root itself, so the mount's own index.js /
+  // package.json "main" decides what runs, exactly as `node <dir>` would.
+
+  const cjsFiles = {
+    'index.js': "console.log('hello from vfs cjs');",
+  };
+
+  {
+    const dir = nextDir('cjs-dir');
+    writeTree(dir, cjsFiles);
+    const result = runVfs(dir);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.strictEqual(result.stdout.trim(), 'hello from vfs cjs');
+  }
+
+  {
+    const dir = nextDir('cjs-zip-src');
+    const zipPath = path.join(dir, 'app.zip');
+    await zipFromTree(cjsFiles, zipPath);
+    const result = runVfs(zipPath);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.strictEqual(result.stdout.trim(), 'hello from vfs cjs');
+  }
+
+  // -- Positional arguments are the app's own, passed straight through as ----
+  // -- argv[2] onward - never treated as an entry-point override. This is ----
+  // -- what lets a self-mounting shebang app (`#!/usr/bin/env node --vfs`) ----
+  // -- take command-line arguments of its own.                            ----
+
+  {
+    const dir = nextDir('argv-passthrough');
+    writeTree(dir, {
+      'index.js': 'console.log(JSON.stringify(process.argv.slice(2)));',
+    });
+    const result = runVfs(dir, ['alpha', 'beta']);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.deepStrictEqual(JSON.parse(result.stdout.trim()), ['alpha', 'beta']);
+  }
+
+  // -- package.json "main" picks the entry file within the mount ------------
+
+  {
+    const dir = nextDir('main-field');
+    writeTree(dir, {
+      'package.json': JSON.stringify({ main: 'src/entry.js' }),
+      'src/entry.js': "console.log('ran package main');",
+    });
+    const result = runVfs(dir);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.strictEqual(result.stdout.trim(), 'ran package main');
+  }
+
+  // -- ESM entry via package.json "type": "module" ---------------------------
+
+  {
+    const dir = nextDir('esm-dir');
+    writeTree(dir, {
+      'package.json': JSON.stringify({ type: 'module' }),
+      'index.js': "console.log('esm entry:', typeof import.meta.url);",
+    });
+    const result = runVfs(dir);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.strictEqual(result.stdout.trim(), 'esm entry: string');
+  }
+
+  // -- Multi-file CJS app: relative require + node_modules resolution -------
+
+  {
+    const dir = nextDir('multi-file');
+    writeTree(dir, {
+      'index.js':
+        "const { greet } = require('./lib/helper.js');\n" +
+        "const pkg = require('mypkg');\n" +
+        "console.log(greet() + '-' + pkg.value);",
+      'lib/helper.js': "module.exports = { greet: () => 'hi' };",
+      'node_modules/mypkg/package.json': JSON.stringify({ name: 'mypkg', main: 'index.js' }),
+      'node_modules/mypkg/index.js': "module.exports = { value: 'pkg-value' };",
+    });
+    const result = runVfs(dir);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.strictEqual(result.stdout.trim(), 'hi-pkg-value');
+  }
+
+  // -- Invalid target ---------------------------------------------------------
+
+  {
+    const missing = path.join(tmpdir.path, 'does-not-exist');
+    const result = runVfs(missing);
+    assert.notStrictEqual(result.status, 0);
+    assert.match(result.stderr, /ERR_VFS_INVALID_TARGET/);
+  }
+
+  // -- Sandbox is scoped to the mount, not the whole real filesystem ---------
+
+  {
+    const dir = nextDir('scoped-dir');
+    const outsideMarker = path.join(tmpdir.path, 'outside-marker.txt');
+    fs.writeFileSync(outsideMarker, 'real content outside the mount');
+    writeTree(dir, {
+      'index.js':
+        "const fs = require('fs');\n" +
+        `console.log(fs.readFileSync(${JSON.stringify(outsideMarker)}, 'utf8'));`,
+    });
+    const result = runVfs(dir);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.strictEqual(result.stdout.trim(), 'real content outside the mount');
+  }
+
+  // -- worker_threads inherits the mount --------------------------------------
+  //
+  // The worker names its entry through `new Worker(__filename)`, resolved via
+  // the (VFS-aware) module loader - independent of the main thread's argv[1].
+
+  {
+    const dir = nextDir('worker-dir');
+    writeTree(dir, {
+      'marker.txt': 'inside the mount',
+      'index.js':
+        "const { Worker, isMainThread, parentPort } = require('worker_threads');\n" +
+        'if (isMainThread) {\n' +
+        '  const w = new Worker(__filename);\n' +
+        "  w.on('message', (msg) => { console.log(msg); });\n" +
+        '} else {\n' +
+        "  const fs = require('fs');\n" +
+        "  const path = require('path');\n" +
+        "  parentPort.postMessage(fs.readFileSync(path.join(__dirname, 'marker.txt'), 'utf8'));\n" +
+        '}',
+    });
+    const result = runVfs(dir);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.strictEqual(result.stdout.trim(), 'inside the mount');
+  }
+})().then(common.mustCall());

--- a/test/parallel/test-vfs-manifest-flag.js
+++ b/test/parallel/test-vfs-manifest-flag.js
@@ -1,0 +1,123 @@
+'use strict';
+
+// Exercises the --vfs-manifest=<file> startup flag: every file actually
+// read through a directory-backed --vfs mount - whether by module
+// resolution or by the program's own plain fs.readFile*() calls - gets its
+// path appended to <file>; the flag requires an explicit output path (no
+// path is derived from the --vfs target), requires --vfs to be set and to
+// target a directory, and a file read by a worker thread also lands in the
+// same manifest (workers append to the same real file directly).
+
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const zlib = require('zlib');
+const { spawnSync } = require('child_process');
+
+tmpdir.refresh();
+let fixtureId = 0;
+function nextDir(name) {
+  const dir = path.join(tmpdir.path, `${fixtureId++}-${name}`);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeTree(dir, files) {
+  for (const { 0: name, 1: content } of Object.entries(files)) {
+    const filePath = path.join(dir, name);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content);
+  }
+}
+
+function runVfs(args) {
+  return spawnSync(process.execPath, args, { encoding: 'utf8' });
+}
+
+function readManifestLines(manifestPath) {
+  return fs.readFileSync(manifestPath, 'utf8').split('\n').filter((l) => l.length > 0);
+}
+
+// -- basic: module reads + a plain fs.readFileSync() both get recorded ----
+
+{
+  const dir = nextDir('basic');
+  const manifestPath = path.join(tmpdir.path, 'basic.manifest');
+  writeTree(dir, {
+    'index.js':
+      "const { greet } = require('./lib/helper.js');\n" +
+      "const fs = require('fs');\n" +
+      "const path = require('path');\n" +
+      'console.log(greet());\n' +
+      "console.log(fs.readFileSync(path.join(__dirname, 'data.txt'), 'utf8'));",
+    'lib/helper.js': "module.exports = { greet: () => 'hi' };",
+    'data.txt': 'some data',
+  });
+  const result = runVfs([`--vfs=${dir}`, `--vfs-manifest=${manifestPath}`]);
+  assert.strictEqual(result.status, 0, result.stderr);
+  assert.strictEqual(result.stdout.trim(), 'hi\nsome data');
+
+  assert.strictEqual(fs.existsSync(manifestPath), true);
+  const lines = readManifestLines(manifestPath);
+  assert.deepStrictEqual(new Set(lines), new Set([
+    'index.js',
+    'lib/helper.js',
+    'data.txt',
+  ]));
+}
+
+// -- requires --vfs -----------------------------------------------------
+
+{
+  const manifestPath = path.join(tmpdir.path, 'unused.manifest');
+  const result = runVfs([`--vfs-manifest=${manifestPath}`, '-e', '0']);
+  assert.notStrictEqual(result.status, 0);
+  assert.match(result.stderr, /ERR_MISSING_OPTION/);
+}
+
+// -- requires --vfs to target a directory, not a zip ---------------------
+
+{
+  const dir = nextDir('zip-src');
+  const zipPath = path.join(dir, 'app.zip');
+  const manifestPath = path.join(tmpdir.path, 'zip-src.manifest');
+  (async () => {
+    const entry = await zlib.ZipEntry.create('index.js', Buffer.from("console.log('hi');"));
+    const chunks = [];
+    for await (const chunk of zlib.createZipArchive([entry])) chunks.push(chunk);
+    fs.writeFileSync(zipPath, Buffer.concat(chunks));
+
+    const result = runVfs([`--vfs=${zipPath}`, `--vfs-manifest=${manifestPath}`]);
+    assert.notStrictEqual(result.status, 0);
+    assert.match(result.stderr, /ERR_VFS_MANIFEST_REQUIRES_DIRECTORY/);
+  })().then(common.mustCall());
+}
+
+// -- a file read by a worker thread lands in the same manifest -----------
+
+{
+  const dir = nextDir('worker-dir');
+  const manifestPath = path.join(tmpdir.path, 'worker-dir.manifest');
+  writeTree(dir, {
+    'worker-data.txt': 'read by the worker',
+    'index.js':
+      "const { Worker, isMainThread, parentPort } = require('worker_threads');\n" +
+      'if (isMainThread) {\n' +
+      '  const w = new Worker(__filename);\n' +
+      "  w.on('message', () => {});\n" +
+      '} else {\n' +
+      "  const fs = require('fs');\n" +
+      "  const path = require('path');\n" +
+      "  fs.readFileSync(path.join(__dirname, 'worker-data.txt'), 'utf8');\n" +
+      '  parentPort.postMessage(\'done\');\n' +
+      '}',
+  });
+  const result = runVfs([`--vfs=${dir}`, `--vfs-manifest=${manifestPath}`]);
+  assert.strictEqual(result.status, 0, result.stderr);
+
+  const lines = readManifestLines(manifestPath);
+  assert.ok(lines.includes('worker-data.txt'), `expected worker-data.txt in ${lines}`);
+  assert.ok(lines.includes('index.js'), `expected index.js in ${lines}`);
+}

--- a/test/parallel/test-vfs-mount-require.js
+++ b/test/parallel/test-vfs-mount-require.js
@@ -1,0 +1,73 @@
+// Flags: --experimental-vfs
+'use strict';
+
+// Regression test: module resolution (require()/createRequire()) must work
+// through *any* mounted VFS - not just one mounted via the --vfs CLI flag.
+// internal/modules/vfs_resolution.js's native-bypass replacements
+// (internalModuleStat, package.json reading, legacyMainResolve, ...) look up
+// the active mount via internal/vfs/setup.js's general activeVFSList, the
+// same registry any vfs.mount() call - CLI-driven or plain userland code -
+// registers with. Before this, they only recognized the CLI's own mount,
+// so requiring a file out of a programmatically-mounted VFS (the pattern a
+// single-executable-application bootstrap script uses: mount an embedded
+// ZipBuffer, then createRequire() into it) would fail with MODULE_NOT_FOUND
+// even though plain fs.readFileSync() against the same path worked fine.
+
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const zlib = require('zlib');
+const { createRequire } = require('module');
+const vfs = require('node:vfs');
+
+tmpdir.refresh();
+
+// -- archive-backed, mounted programmatically (no --vfs flag involved) ----
+
+(async () => {
+  const entries = [
+    await zlib.ZipEntry.create('app.js',
+                               Buffer.from("module.exports = require('./lib/helper.js').greet();")),
+    await zlib.ZipEntry.create('lib/helper.js',
+                               Buffer.from("module.exports = { greet: () => 'hi from zip' };")),
+  ];
+  const chunks = [];
+  for await (const chunk of zlib.createZipArchive(entries)) chunks.push(chunk);
+  const archive = Buffer.concat(chunks);
+
+  const zip = new zlib.ZipBuffer(archive);
+  const provider = new vfs.ZipProvider(zip);
+  const myVfs = vfs.create(provider);
+  myVfs.mount('/zip-app');
+
+  // Plain fs calls already worked before this fix; confirm they still do.
+  assert.strictEqual(fs.existsSync('/zip-app/app.js'), true);
+
+  // The actual regression: require() through the same mount.
+  const result = createRequire('/zip-app/_.js')('./app.js');
+  assert.strictEqual(result, 'hi from zip');
+
+  myVfs.unmount();
+})().then(common.mustCall());
+
+// -- directory-backed, mounted programmatically ----------------------------
+
+{
+  const dir = path.join(tmpdir.path, 'dir-app');
+  fs.mkdirSync(path.join(dir, 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'app.js'),
+                   "module.exports = require('./lib/helper.js').greet();");
+  fs.writeFileSync(path.join(dir, 'lib', 'helper.js'),
+                   "module.exports = { greet: () => 'hi from dir' };");
+
+  const provider = new vfs.RealFSProvider(dir);
+  const myVfs = vfs.create(provider);
+  myVfs.mount('/dir-app');
+
+  const result = createRequire('/dir-app/_.js')('./app.js');
+  assert.strictEqual(result, 'hi from dir');
+
+  myVfs.unmount();
+}

--- a/test/parallel/test-vfs-zip-provider-handle.js
+++ b/test/parallel/test-vfs-zip-provider-handle.js
@@ -1,0 +1,443 @@
+// Flags: --experimental-vfs
+'use strict';
+
+// Additional ZipProvider coverage beyond test-vfs-zip-provider.js:
+// direct ZipFileHandle read/write/stat/truncate (both explicit and
+// current position, append-mode positioning, buffer growth), readFile/
+// writeFile encoding and data-type variants, compression-method-preserving
+// rename() (methodOption()), ZipFile-backed synchronous delete, an explicit
+// empty-directory open() EISDIR, the readdir child-directory dedup path, and
+// a few error branches (EROFS on open(), ENOTDIR on rmdir(), ENOENT on
+// rename()) not exercised by the base test.
+
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const path = require('path');
+const fsPromises = require('fs/promises');
+const zlib = require('zlib');
+const vfs = require('node:vfs');
+
+tmpdir.refresh();
+
+async function buildArchive(entries, comment) {
+  const chunks = [];
+  for await (const chunk of zlib.createZipArchive(entries, comment)) chunks.push(chunk);
+  return Buffer.concat(chunks);
+}
+
+function buildArchiveSync(entries, comment) {
+  return Buffer.concat([...zlib.createZipArchiveSync(entries, comment)]);
+}
+
+// --- direct ZipFileHandle read/write/stat/truncate (async) -------------
+(async () => {
+  const archive = await buildArchive([
+    await zlib.ZipEntry.create('a.txt', Buffer.from('hello world')),
+  ]);
+  const zip = new zlib.ZipBuffer(archive);
+  const provider = new vfs.ZipProvider(zip);
+
+  const handle = await provider.open('/a.txt', 'r+');
+
+  // Explicit position leaves the handle's own position untouched.
+  const buf = Buffer.alloc(5);
+  const { bytesRead } = await handle.read(buf, 0, 5, 0);
+  assert.strictEqual(bytesRead, 5);
+  assert.strictEqual(buf.toString(), 'hello');
+  assert.strictEqual(handle.position, 0);
+
+  // Current position (undefined/null/-1) advances the handle's position.
+  const buf2 = Buffer.alloc(5);
+  await handle.read(buf2, 0, 5, null);
+  assert.strictEqual(buf2.toString(), 'hello');
+  assert.strictEqual(handle.position, 5);
+  const buf3 = Buffer.alloc(1);
+  await handle.read(buf3, 0, 1, -1);
+  assert.strictEqual(buf3.toString(), ' ');
+  assert.strictEqual(handle.position, 6);
+
+  // Reading past EOF yields 0 bytes without advancing further than available.
+  const tail = Buffer.alloc(100);
+  const { bytesRead: tailRead } = await handle.read(tail, 0, 100, 6);
+  assert.strictEqual(tailRead, 5); // 'world'.length
+
+  // write() at an explicit position (overwrite), then at the current
+  // position (append past the buffer's current size, forcing growth).
+  await handle.write(Buffer.from('HELLO'), 0, 5, 0);
+  const stat1 = await handle.stat();
+  assert.strictEqual(stat1.size, 11);
+
+  handle.position = 11;
+  await handle.write(Buffer.from('!!!'), 0, 3, null);
+  const stat2 = await handle.stat();
+  assert.strictEqual(stat2.size, 14);
+
+  await handle.truncate(5);
+  const stat3 = await handle.stat();
+  assert.strictEqual(stat3.size, 5);
+
+  await handle.truncate(8);
+  const stat4 = await handle.stat();
+  assert.strictEqual(stat4.size, 8);
+
+  await handle.close();
+
+  const archiveVfs = vfs.create(provider);
+  const final = await archiveVfs.promises.readFile('/a.txt');
+  assert.strictEqual(final.length, 8);
+  assert.strictEqual(final.subarray(0, 5).toString(), 'HELLO');
+})().then(common.mustCall());
+
+// --- direct ZipFileHandle read/write/stat/truncate (sync) --------------
+(() => {
+  const archive = buildArchiveSync([zlib.ZipEntry.createSync('b.txt', Buffer.from('0123456789'))]);
+  const zip = new zlib.ZipBuffer(archive);
+  const provider = new vfs.ZipProvider(zip);
+  const handle = provider.openSync('/b.txt', 'r+');
+
+  const buf = Buffer.alloc(4);
+  const { bytesRead } = handle.readSync(buf, 0, 4, 2);
+  assert.strictEqual(bytesRead, 4);
+  assert.strictEqual(buf.toString(), '2345');
+
+  handle.writeSync(Buffer.from('AB'), 0, 2, 0);
+  assert.strictEqual(handle.statSync().size, 10);
+
+  // A write growing well beyond current capacity exercises #ensureCapacity's
+  // doubling path.
+  handle.writeSync(Buffer.alloc(1000, 0x58 /* 'X' */), 0, 1000, 10);
+  assert.strictEqual(handle.statSync().size, 1010);
+
+  handle.truncateSync(3);
+  assert.strictEqual(handle.statSync().size, 3);
+  assert.strictEqual(handle.readFileSync('utf8'), 'AB2');
+
+  handle.closeSync();
+})();
+
+// --- append-mode positioning: writes always land at the current end -------
+(async () => {
+  const archive = await buildArchive([await zlib.ZipEntry.create('c.txt', Buffer.from('xy'))]);
+  const zip = new zlib.ZipBuffer(archive);
+  const provider = new vfs.ZipProvider(zip);
+
+  const handle = await provider.open('/c.txt', 'a');
+  assert.strictEqual(handle.position, 2); // Positioned at EOF on open
+
+  // Even with an explicit (wrong) position, append mode writes at the end.
+  await handle.write(Buffer.from('z'), 0, 1, 0);
+  assert.strictEqual((await handle.stat()).size, 3);
+  await handle.close();
+
+  const archiveVfs = vfs.create(provider);
+  assert.strictEqual(await archiveVfs.promises.readFile('/c.txt', 'utf8'), 'xyz');
+})().then(common.mustCall());
+
+// --- readFile/readFileSync encoding variants + writeFile data types --------
+(async () => {
+  const archive = await buildArchive([await zlib.ZipEntry.create('d.txt', Buffer.from('café'))]);
+  const zip = new zlib.ZipBuffer(archive);
+  const provider = new vfs.ZipProvider(zip);
+
+  const handle = await provider.open('/d.txt', 'r');
+  const asBuffer = await handle.readFile();
+  assert.ok(Buffer.isBuffer(asBuffer));
+  const asStringShorthand = await handle.readFile('utf8');
+  assert.strictEqual(asStringShorthand, 'café');
+  const asStringOption = await handle.readFile({ encoding: 'utf8' });
+  assert.strictEqual(asStringOption, 'café');
+  const asExplicitBuffer = await handle.readFile({ encoding: 'buffer' });
+  assert.ok(Buffer.isBuffer(asExplicitBuffer));
+  await handle.close();
+
+  const writeHandle = await provider.open('/e.txt', 'w');
+  await writeHandle.writeFile(Buffer.from('buffer-data'));
+  await writeHandle.close();
+  assert.strictEqual(await (await provider.open('/e.txt', 'r')).readFile('utf8'), 'buffer-data');
+
+  const writeHandle2 = await provider.open('/f.txt', 'w');
+  await writeHandle2.writeFile('string-data', { encoding: 'utf8' });
+  await writeHandle2.close();
+  assert.strictEqual(await (await provider.open('/f.txt', 'r')).readFile('utf8'), 'string-data');
+})().then(common.mustCall());
+
+(() => {
+  const archive = buildArchiveSync([zlib.ZipEntry.createSync('g.txt', Buffer.from('sync-café'))]);
+  const zip = new zlib.ZipBuffer(archive);
+  const provider = new vfs.ZipProvider(zip);
+
+  const handle = provider.openSync('/g.txt', 'r');
+  assert.ok(Buffer.isBuffer(handle.readFileSync()));
+  assert.strictEqual(handle.readFileSync('utf8'), 'sync-café');
+  assert.strictEqual(handle.readFileSync({ encoding: 'utf8' }), 'sync-café');
+  assert.ok(Buffer.isBuffer(handle.readFileSync({ encoding: 'buffer' })));
+  handle.closeSync();
+
+  const writeHandle = provider.openSync('/h.txt', 'w');
+  writeHandle.writeFileSync(Buffer.from('sync-buffer-data'));
+  writeHandle.closeSync();
+  assert.strictEqual(provider.openSync('/h.txt', 'r').readFileSync('utf8'), 'sync-buffer-data');
+})();
+
+// --- rename() preserves the original compression method (methodOption) ----
+(async () => {
+  const archive = await buildArchive([
+    await zlib.ZipEntry.create('store.bin', Buffer.from('a'.repeat(100)), { method: 'store' }),
+    await zlib.ZipEntry.create('deflate.bin', Buffer.from('b'.repeat(100)), { method: 'deflate' }),
+    await zlib.ZipEntry.create('zstd.bin', Buffer.from('c'.repeat(100)), { method: 'zstd' }),
+  ]);
+  const zip = new zlib.ZipBuffer(archive);
+  const provider = new vfs.ZipProvider(zip);
+  const archiveVfs = vfs.create(provider);
+
+  const methodsBefore = new Map([
+    ['store.bin', zip.get('store.bin').method],
+    ['deflate.bin', zip.get('deflate.bin').method],
+    ['zstd.bin', zip.get('zstd.bin').method],
+  ]);
+
+  await archiveVfs.promises.rename('/store.bin', '/store-renamed.bin');
+  await archiveVfs.promises.rename('/deflate.bin', '/deflate-renamed.bin');
+  await archiveVfs.promises.rename('/zstd.bin', '/zstd-renamed.bin');
+
+  assert.strictEqual(zip.get('store-renamed.bin').method, methodsBefore.get('store.bin'));
+  assert.strictEqual(zip.get('deflate-renamed.bin').method, methodsBefore.get('deflate.bin'));
+  assert.strictEqual(zip.get('zstd-renamed.bin').method, methodsBefore.get('zstd.bin'));
+
+  // Content must still round-trip correctly under the reproduced method.
+  assert.strictEqual((await zip.get('store-renamed.bin').content()).toString(), 'a'.repeat(100));
+  assert.strictEqual((await zip.get('deflate-renamed.bin').content()).toString(), 'b'.repeat(100));
+  assert.strictEqual((await zip.get('zstd-renamed.bin').content()).toString(), 'c'.repeat(100));
+})().then(common.mustCall());
+
+(() => {
+  const archive = buildArchiveSync([
+    zlib.ZipEntry.createSync('store.bin', Buffer.from('a'.repeat(100)), { method: 'store' }),
+    zlib.ZipEntry.createSync('zstd.bin', Buffer.from('c'.repeat(100)), { method: 'zstd' }),
+  ]);
+  const zip = new zlib.ZipBuffer(archive);
+  const provider = new vfs.ZipProvider(zip);
+  const archiveVfs = vfs.create(provider);
+
+  const storeMethod = zip.get('store.bin').method;
+  const zstdMethod = zip.get('zstd.bin').method;
+  archiveVfs.renameSync('/store.bin', '/store-renamed.bin');
+  archiveVfs.renameSync('/zstd.bin', '/zstd-renamed.bin');
+  assert.strictEqual(zip.get('store-renamed.bin').method, storeMethod);
+  assert.strictEqual(zip.get('zstd-renamed.bin').method, zstdMethod);
+})();
+
+// --- rename() with a missing source is rejected with ENOENT ---------------
+(async () => {
+  const archive = await buildArchive([await zlib.ZipEntry.create('only.txt', Buffer.from('x'))]);
+  const zip = new zlib.ZipBuffer(archive);
+  const provider = new vfs.ZipProvider(zip);
+  const archiveVfs = vfs.create(provider);
+
+  await assert.rejects(
+    archiveVfs.promises.rename('/missing.txt', '/renamed.txt'),
+    { code: 'ENOENT' },
+  );
+  assert.throws(
+    () => archiveVfs.renameSync('/missing.txt', '/renamed.txt'),
+    { code: 'ENOENT' },
+  );
+})().then(common.mustCall());
+
+// --- rmdir() on a plain file is rejected with ENOTDIR ----------------------
+// (called on the provider directly: the vfs router validates directory-ness
+// itself before delegating for some operations, which would otherwise never
+// exercise ZipProvider's own check).
+(async () => {
+  const archive = await buildArchive([await zlib.ZipEntry.create('file.txt', Buffer.from('x'))]);
+  const zip = new zlib.ZipBuffer(archive);
+  const provider = new vfs.ZipProvider(zip);
+
+  await assert.rejects(provider.rmdir('/file.txt'), { code: 'ENOTDIR' });
+  assert.throws(() => provider.rmdirSync('/file.txt'), { code: 'ENOTDIR' });
+})().then(common.mustCall());
+
+// --- open(): EEXIST/ENOENT/EISDIR-on-wrong-direction, called directly on
+// the provider so the router can't short-circuit before delegating ---------
+(async () => {
+  const archive = await buildArchive([await zlib.ZipEntry.create('a.txt', Buffer.from('x'))]);
+  const zip = new zlib.ZipBuffer(archive);
+  const provider = new vfs.ZipProvider(zip);
+
+  await assert.rejects(provider.open('/a.txt', 'wx'), { code: 'EEXIST' });
+  assert.throws(() => provider.openSync('/a.txt', 'wx'), { code: 'EEXIST' });
+  await assert.rejects(provider.open('/missing.txt', 'r'), { code: 'ENOENT' });
+  assert.throws(() => provider.openSync('/missing.txt', 'r'), { code: 'ENOENT' });
+
+  // A handle opened write-only can't be read from, and vice versa.
+  const writeOnly = await provider.open('/w.txt', 'w');
+  await assert.rejects(writeOnly.read(Buffer.alloc(1), 0, 1, 0), { code: 'EISDIR' });
+  await writeOnly.close();
+  const readOnly = await provider.open('/a.txt', 'r');
+  await assert.rejects(readOnly.write(Buffer.alloc(1), 0, 1, 0), { code: 'EISDIR' });
+  await readOnly.close();
+})().then(common.mustCall());
+
+// --- normalize(): a path without a leading slash is used as-is ------------
+(async () => {
+  const archive = await buildArchive([await zlib.ZipEntry.create('a.txt', Buffer.from('x'))]);
+  const zip = new zlib.ZipBuffer(archive);
+  const provider = new vfs.ZipProvider(zip);
+
+  const stats = await provider.stat('a.txt');
+  assert.strictEqual(stats.isFile(), true);
+})().then(common.mustCall());
+
+// --- mkdir(): both the with-options and no-options shapes, called
+// directly on the provider ---------------------------------------------
+(async () => {
+  const archive = await buildArchive([]);
+  const zip = new zlib.ZipBuffer(archive);
+  const provider = new vfs.ZipProvider(zip);
+
+  await provider.mkdir('/no-opts');
+  assert.strictEqual((await provider.stat('/no-opts')).isDirectory(), true);
+  await provider.mkdir('/with-opts', { mode: 0o700 });
+  assert.strictEqual((await provider.stat('/with-opts')).isDirectory(), true);
+
+  provider.mkdirSync('/no-opts-sync');
+  assert.strictEqual(provider.statSync('/no-opts-sync').isDirectory(), true);
+  provider.mkdirSync('/with-opts-sync', { mode: 0o700 });
+  assert.strictEqual(provider.statSync('/with-opts-sync').isDirectory(), true);
+})().then(common.mustCall());
+
+// --- readdir() skips a directory's own explicit entry when listing it -----
+(async () => {
+  const archive = await buildArchive([
+    await zlib.ZipEntry.create('dir/', Buffer.alloc(0)),
+    await zlib.ZipEntry.create('dir/child.txt', Buffer.from('x')),
+  ]);
+  const zip = new zlib.ZipBuffer(archive);
+  const provider = new vfs.ZipProvider(zip);
+  const archiveVfs = vfs.create(provider);
+
+  const entries = await archiveVfs.promises.readdir('/dir');
+  assert.deepStrictEqual(entries, ['child.txt']);
+})().then(common.mustCall());
+
+// --- an entry not made by a Unix zip tool reports mode 0, so stat() and
+// rename() fall back to their documented defaults --------------------------
+(async () => {
+  const archive = await buildArchive([
+    await zlib.ZipEntry.create('foreign.txt', Buffer.from('x')),
+    await zlib.ZipEntry.create('foreign-dir/', Buffer.alloc(0)),
+  ]);
+  const tampered = Buffer.from(archive);
+  // The central header's "version made by" high byte selects the platform;
+  // anything other than 3 (Unix) makes `mode` report 0 (see zip.js's
+  // `CentralFileHeader.prototype.mode`).
+  // The central directory follows *all* entries' local sections, and each
+  // entry's central header follows the previous entries' central headers.
+  const localSectionsLength = (30 + 'foreign.txt'.length + 'x'.length) +
+    (30 + 'foreign-dir/'.length + 0);
+  const fileHeaderStart = localSectionsLength;
+  const dirHeaderStart = fileHeaderStart + (46 + 'foreign.txt'.length);
+  const fileMadeByOffset = fileHeaderStart + 5;
+  const dirMadeByOffset = dirHeaderStart + 5;
+  assert.strictEqual(tampered[fileMadeByOffset], 3); // sanity: was Unix-made
+  assert.strictEqual(tampered[dirMadeByOffset], 3);
+  tampered[fileMadeByOffset] = 0; // MS-DOS/FAT
+  tampered[dirMadeByOffset] = 0;
+
+  const zip = new zlib.ZipBuffer(tampered);
+  assert.strictEqual(zip.get('foreign.txt').mode, 0);
+  assert.strictEqual(zip.get('foreign-dir/').mode, 0);
+  const provider = new vfs.ZipProvider(zip);
+  const archiveVfs = vfs.create(provider);
+
+  // stat()'s `entry.mode || <default>` fallback, for both a file and an
+  // (explicit) directory entry.
+  const fileStats = await archiveVfs.promises.stat('/foreign.txt');
+  assert.strictEqual(fileStats.mode & 0o777, 0o644);
+  const dirStats = await archiveVfs.promises.stat('/foreign-dir');
+  assert.strictEqual(dirStats.mode & 0o777, 0o755);
+  assert.strictEqual(archiveVfs.statSync('/foreign.txt').mode & 0o777, 0o644);
+  assert.strictEqual(archiveVfs.statSync('/foreign-dir').mode & 0o777, 0o755);
+
+  // rename()'s `mode: entry.mode || undefined` fallback (undefined lets
+  // ZipEntry.create() pick its own default mode instead of reproducing 0).
+  await archiveVfs.promises.rename('/foreign.txt', '/renamed.txt');
+  assert.strictEqual((await archiveVfs.promises.stat('/renamed.txt')).mode & 0o777, 0o644);
+})().then(common.mustCall());
+
+(() => {
+  const archive = buildArchiveSync([zlib.ZipEntry.createSync('foreign.txt', Buffer.from('x'))]);
+  const tampered = Buffer.from(archive);
+  const centralHeaderStart = 30 + 'foreign.txt'.length + 'x'.length;
+  const madeByOffset = centralHeaderStart + 5;
+  tampered[madeByOffset] = 0;
+
+  const zip = new zlib.ZipBuffer(tampered);
+  const provider = new vfs.ZipProvider(zip);
+  const archiveVfs = vfs.create(provider);
+
+  archiveVfs.renameSync('/foreign.txt', '/renamed.txt');
+  assert.strictEqual(archiveVfs.statSync('/renamed.txt').mode & 0o777, 0o644);
+})();
+
+// --- opening an explicit (empty) directory entry is rejected with EISDIR --
+(async () => {
+  const archive = await buildArchive([await zlib.ZipEntry.create('empty-dir/', Buffer.alloc(0))]);
+  const zip = new zlib.ZipBuffer(archive);
+  const provider = new vfs.ZipProvider(zip);
+
+  await assert.rejects(provider.open('/empty-dir', 'r'), { code: 'EISDIR' });
+  assert.throws(() => provider.openSync('/empty-dir', 'r'), { code: 'EISDIR' });
+})().then(common.mustCall());
+
+// --- readdir dedups a child directory reached through multiple entries ----
+(async () => {
+  const archive = await buildArchive([
+    await zlib.ZipEntry.create('dir/one.txt', Buffer.from('1')),
+    await zlib.ZipEntry.create('dir/two.txt', Buffer.from('2')),
+  ]);
+  const zip = new zlib.ZipBuffer(archive);
+  const provider = new vfs.ZipProvider(zip);
+  const archiveVfs = vfs.create(provider);
+
+  // Both entries imply the same 'dir' child at the root; it must appear once.
+  const rootEntries = await archiveVfs.promises.readdir('/');
+  assert.deepStrictEqual(rootEntries, ['dir']);
+  const dirEntries = await archiveVfs.promises.readdir('/dir');
+  assert.deepStrictEqual(dirEntries.sort(), ['one.txt', 'two.txt']);
+})().then(common.mustCall());
+
+// --- open() with a write flag against a readonly (ZipFile) archive: EROFS --
+(async () => {
+  const archive = await buildArchive([await zlib.ZipEntry.create('a.txt', Buffer.from('x'))]);
+  const filePath = path.join(tmpdir.path, 'vfs-archive-handle-readonly.zip');
+  await fsPromises.writeFile(filePath, archive);
+  const zip = await zlib.ZipFile.open(filePath);
+  const provider = new vfs.ZipProvider(zip);
+
+  await assert.rejects(provider.open('/new.txt', 'w'), { code: 'EROFS' });
+  assert.throws(() => provider.openSync('/new.txt', 'w'), { code: 'EROFS' });
+
+  await zip.close();
+})().then(common.mustCall());
+
+// --- ZipFile-backed writable archive: sync unlink/rmdir (deleteSync) ------
+(async () => {
+  const archive = await buildArchive([await zlib.ZipEntry.create('a.txt', Buffer.from('x'))]);
+  const filePath = path.join(tmpdir.path, 'vfs-archive-handle-writable-sync.zip');
+  await fsPromises.writeFile(filePath, archive);
+  const zip = await zlib.ZipFile.open(filePath, { writable: true });
+  const provider = new vfs.ZipProvider(zip);
+  const archiveVfs = vfs.create(provider);
+
+  archiveVfs.mkdirSync('/somedir');
+  assert.strictEqual(archiveVfs.statSync('/somedir').isDirectory(), true);
+  archiveVfs.rmdirSync('/somedir');
+  assert.throws(() => archiveVfs.statSync('/somedir'), { code: 'ENOENT' });
+
+  archiveVfs.unlinkSync('/a.txt');
+  assert.throws(() => archiveVfs.statSync('/a.txt'), { code: 'ENOENT' });
+
+  await zip.close();
+})().then(common.mustCall());

--- a/test/parallel/test-vfs-zip-provider.js
+++ b/test/parallel/test-vfs-zip-provider.js
@@ -1,0 +1,243 @@
+// Flags: --experimental-vfs
+'use strict';
+
+// Exercises ZipProvider (node:vfs backed by node:zlib's ZipBuffer/
+// ZipFile): construction validation, readonly reflecting the archive's own
+// writability, stat/readdir over explicit and implicit directories, and the
+// full async and synchronous CRUD surface, against both a ZipBuffer and a
+// ZipFile (opened both via open() and openSync()) source.
+
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const path = require('path');
+const fsPromises = require('fs/promises');
+const zlib = require('zlib');
+const vfs = require('node:vfs');
+
+tmpdir.refresh();
+
+async function buildArchive(entries, comment) {
+  const chunks = [];
+  for await (const chunk of zlib.createZipArchive(entries, comment)) chunks.push(chunk);
+  return Buffer.concat(chunks);
+}
+
+(async () => {
+  // Construction validation.
+  assert.throws(() => new vfs.ZipProvider({}), { code: 'ERR_INVALID_ARG_TYPE' });
+  assert.throws(() => new vfs.ZipProvider(null), { code: 'ERR_INVALID_ARG_TYPE' });
+
+  // --- ZipBuffer-backed: always writable ------------------------------------
+  {
+    const archive = await buildArchive([
+      await zlib.ZipEntry.create('a.txt', Buffer.from('hello')),
+      await zlib.ZipEntry.create('dir/b.txt', Buffer.from('nested')),
+      await zlib.ZipEntry.create('empty-dir/', Buffer.alloc(0)),
+    ]);
+    const zip = new zlib.ZipBuffer(archive);
+    const provider = new vfs.ZipProvider(zip);
+    assert.strictEqual(provider.readonly, false);
+    assert.strictEqual(provider.supportsSymlinks, false);
+    assert.strictEqual(provider.supportsWatch, false);
+
+    const archiveVfs = vfs.create(provider);
+
+    // stat: file, implicit directory, explicit directory, root.
+    const fileStat = await archiveVfs.promises.stat('/a.txt');
+    assert.strictEqual(fileStat.isFile(), true);
+    assert.strictEqual(fileStat.size, 5);
+
+    const implicitDirStat = await archiveVfs.promises.stat('/dir');
+    assert.strictEqual(implicitDirStat.isDirectory(), true);
+
+    const explicitDirStat = await archiveVfs.promises.stat('/empty-dir');
+    assert.strictEqual(explicitDirStat.isDirectory(), true);
+
+    const rootStat = await archiveVfs.promises.stat('/');
+    assert.strictEqual(rootStat.isDirectory(), true);
+
+    await assert.rejects(archiveVfs.promises.stat('/missing.txt'), { code: 'ENOENT' });
+
+    // readdir: root lists both files and directories, deduped.
+    const rootEntries = await archiveVfs.promises.readdir('/');
+    assert.deepStrictEqual(rootEntries.sort(), ['a.txt', 'dir', 'empty-dir']);
+
+    const dirEntries = await archiveVfs.promises.readdir('/dir');
+    assert.deepStrictEqual(dirEntries, ['b.txt']);
+
+    const withTypes = await archiveVfs.promises.readdir('/', { withFileTypes: true });
+    const byName = new Map(withTypes.map((d) => [d.name, d]));
+    assert.strictEqual(byName.get('a.txt').isFile(), true);
+    assert.strictEqual(byName.get('dir').isDirectory(), true);
+
+    await assert.rejects(archiveVfs.promises.readdir('/a.txt'), { code: 'ENOTDIR' });
+    await assert.rejects(
+      archiveVfs.promises.readdir('/', { recursive: true }),
+      { code: 'ERR_METHOD_NOT_IMPLEMENTED' },
+    );
+
+    // readFile / writeFile round trip (new file).
+    assert.strictEqual(await archiveVfs.promises.readFile('/a.txt', 'utf8'), 'hello');
+    await archiveVfs.promises.writeFile('/new.txt', 'brand new');
+    assert.strictEqual(await archiveVfs.promises.readFile('/new.txt', 'utf8'), 'brand new');
+    assert.strictEqual(zip.has('new.txt'), true);
+
+    // Overwriting an existing file.
+    await archiveVfs.promises.writeFile('/a.txt', 'overwritten');
+    assert.strictEqual(await archiveVfs.promises.readFile('/a.txt', 'utf8'), 'overwritten');
+
+    // appendFile.
+    await archiveVfs.promises.writeFile('/append.txt', 'ab');
+    await archiveVfs.promises.appendFile('/append.txt', 'cd');
+    assert.strictEqual(await archiveVfs.promises.readFile('/append.txt', 'utf8'), 'abcd');
+
+    // mkdir + rmdir.
+    await archiveVfs.promises.mkdir('/newdir');
+    assert.strictEqual((await archiveVfs.promises.stat('/newdir')).isDirectory(), true);
+    await assert.rejects(archiveVfs.promises.mkdir('/newdir'), { code: 'EEXIST' });
+    await archiveVfs.promises.mkdir('/newdir', { recursive: true }); // No throw, already exists
+    await archiveVfs.promises.rmdir('/newdir');
+    await assert.rejects(archiveVfs.promises.stat('/newdir'), { code: 'ENOENT' });
+
+    // Rmdir refuses a non-empty directory.
+    await assert.rejects(archiveVfs.promises.rmdir('/dir'), { code: 'ENOTEMPTY' });
+
+    // unlink.
+    await archiveVfs.promises.unlink('/append.txt');
+    await assert.rejects(archiveVfs.promises.stat('/append.txt'), { code: 'ENOENT' });
+    await assert.rejects(archiveVfs.promises.unlink('/missing.txt'), { code: 'ENOENT' });
+    await assert.rejects(archiveVfs.promises.unlink('/dir'), { code: 'EISDIR' });
+
+    // rename.
+    await archiveVfs.promises.writeFile('/rename-me.txt', 'content');
+    await archiveVfs.promises.rename('/rename-me.txt', '/renamed.txt');
+    assert.strictEqual(zip.has('rename-me.txt'), false);
+    assert.strictEqual(await archiveVfs.promises.readFile('/renamed.txt', 'utf8'), 'content');
+
+    // open() flag semantics.
+    await assert.rejects(archiveVfs.promises.open('/does-not-exist.txt', 'r'), { code: 'ENOENT' });
+    await assert.rejects(archiveVfs.promises.open('/a.txt', 'wx'), { code: 'EEXIST' });
+    await assert.rejects(archiveVfs.promises.open('/dir', 'r'), { code: 'EISDIR' });
+  }
+
+  // --- ZipFile-backed, read-only: writes rejected with EROFS ----------------
+  {
+    const archive = await buildArchive([await zlib.ZipEntry.create('a.txt', Buffer.from('x'))]);
+    const filePath = path.join(tmpdir.path, 'vfs-archive-readonly.zip');
+    await fsPromises.writeFile(filePath, archive);
+    const zip = await zlib.ZipFile.open(filePath);
+    const provider = new vfs.ZipProvider(zip);
+    assert.strictEqual(provider.readonly, true);
+    const archiveVfs = vfs.create(provider);
+
+    assert.strictEqual(await archiveVfs.promises.readFile('/a.txt', 'utf8'), 'x');
+    await assert.rejects(archiveVfs.promises.writeFile('/new.txt', 'y'), { code: 'EROFS' });
+    await assert.rejects(archiveVfs.promises.unlink('/a.txt'), { code: 'EROFS' });
+    await assert.rejects(archiveVfs.promises.mkdir('/newdir'), { code: 'EROFS' });
+    await assert.rejects(archiveVfs.promises.rmdir('/newdir'), { code: 'EROFS' });
+    await assert.rejects(archiveVfs.promises.rename('/a.txt', '/b.txt'), { code: 'EROFS' });
+
+    // The synchronous surface rejects the same way.
+    assert.strictEqual(archiveVfs.readFileSync('/a.txt', 'utf8'), 'x');
+    assert.throws(() => archiveVfs.writeFileSync('/new.txt', 'y'), { code: 'EROFS' });
+    assert.throws(() => archiveVfs.unlinkSync('/a.txt'), { code: 'EROFS' });
+    assert.throws(() => archiveVfs.mkdirSync('/newdir'), { code: 'EROFS' });
+    assert.throws(() => archiveVfs.rmdirSync('/newdir'), { code: 'EROFS' });
+    assert.throws(() => archiveVfs.renameSync('/a.txt', '/b.txt'), { code: 'EROFS' });
+
+    await zip.close();
+  }
+
+  // --- ZipFile-backed, opened writable: mutations persist to disk ----------
+  {
+    const archive = await buildArchive([await zlib.ZipEntry.create('a.txt', Buffer.from('x'))]);
+    const filePath = path.join(tmpdir.path, 'vfs-archive-writable.zip');
+    await fsPromises.writeFile(filePath, archive);
+    const zip = await zlib.ZipFile.open(filePath, { writable: true });
+    const provider = new vfs.ZipProvider(zip);
+    assert.strictEqual(provider.readonly, false);
+    const archiveVfs = vfs.create(provider);
+
+    await archiveVfs.promises.writeFile('/b.txt', 'new content');
+    await zip.close();
+
+    const reopened = await zlib.ZipFile.open(filePath);
+    assert.strictEqual((await (await reopened.get('b.txt')).content()).toString(), 'new content');
+    await reopened.close();
+  }
+
+  // --- ZipBuffer-backed, fully synchronous CRUD ------------------------------
+  {
+    const archive = await buildArchive([
+      await zlib.ZipEntry.create('a.txt', Buffer.from('hello')),
+      await zlib.ZipEntry.create('dir/b.txt', Buffer.from('nested')),
+    ]);
+    const zip = new zlib.ZipBuffer(archive);
+    const provider = new vfs.ZipProvider(zip);
+    const archiveVfs = vfs.create(provider);
+
+    // stat/readdir.
+    assert.strictEqual(archiveVfs.statSync('/a.txt').isFile(), true);
+    assert.strictEqual(archiveVfs.statSync('/dir').isDirectory(), true);
+    assert.throws(() => archiveVfs.statSync('/missing.txt'), { code: 'ENOENT' });
+    assert.deepStrictEqual(archiveVfs.readdirSync('/').sort(), ['a.txt', 'dir']);
+    assert.throws(() => archiveVfs.readdirSync('/a.txt'), { code: 'ENOTDIR' });
+    assert.throws(
+      () => archiveVfs.readdirSync('/', { recursive: true }),
+      { code: 'ERR_METHOD_NOT_IMPLEMENTED' },
+    );
+
+    // readFile/writeFile/appendFile round trip.
+    assert.strictEqual(archiveVfs.readFileSync('/a.txt', 'utf8'), 'hello');
+    archiveVfs.writeFileSync('/new.txt', 'brand new');
+    assert.strictEqual(archiveVfs.readFileSync('/new.txt', 'utf8'), 'brand new');
+    archiveVfs.appendFileSync('/new.txt', '!');
+    assert.strictEqual(archiveVfs.readFileSync('/new.txt', 'utf8'), 'brand new!');
+
+    // mkdir/rmdir.
+    archiveVfs.mkdirSync('/newdir');
+    assert.strictEqual(archiveVfs.statSync('/newdir').isDirectory(), true);
+    assert.throws(() => archiveVfs.mkdirSync('/newdir'), { code: 'EEXIST' });
+    archiveVfs.mkdirSync('/newdir', { recursive: true }); // No throw, already exists.
+    archiveVfs.rmdirSync('/newdir');
+    assert.throws(() => archiveVfs.statSync('/newdir'), { code: 'ENOENT' });
+    assert.throws(() => archiveVfs.rmdirSync('/dir'), { code: 'ENOTEMPTY' });
+
+    // unlink.
+    archiveVfs.unlinkSync('/new.txt');
+    assert.throws(() => archiveVfs.statSync('/new.txt'), { code: 'ENOENT' });
+    assert.throws(() => archiveVfs.unlinkSync('/missing.txt'), { code: 'ENOENT' });
+    assert.throws(() => archiveVfs.unlinkSync('/dir'), { code: 'EISDIR' });
+
+    // rename.
+    archiveVfs.writeFileSync('/rename-me.txt', 'content');
+    archiveVfs.renameSync('/rename-me.txt', '/renamed.txt');
+    assert.strictEqual(zip.has('rename-me.txt'), false);
+    assert.strictEqual(archiveVfs.readFileSync('/renamed.txt', 'utf8'), 'content');
+
+    // open() flag semantics.
+    assert.throws(() => archiveVfs.openSync('/does-not-exist.txt', 'r'), { code: 'ENOENT' });
+    assert.throws(() => archiveVfs.openSync('/a.txt', 'wx'), { code: 'EEXIST' });
+    assert.throws(() => archiveVfs.openSync('/dir', 'r'), { code: 'EISDIR' });
+  }
+
+  // --- ZipFile-backed via openSync: sync-only round trip on disk -----------
+  {
+    const archive = await buildArchive([await zlib.ZipEntry.create('a.txt', Buffer.from('x'))]);
+    const filePath = path.join(tmpdir.path, 'vfs-archive-opensync.zip');
+    await fsPromises.writeFile(filePath, archive);
+    const zip = zlib.ZipFile.openSync(filePath, { writable: true });
+    const provider = new vfs.ZipProvider(zip);
+    assert.strictEqual(provider.readonly, false);
+    const archiveVfs = vfs.create(provider);
+
+    assert.strictEqual(archiveVfs.readFileSync('/a.txt', 'utf8'), 'x');
+    archiveVfs.writeFileSync('/b.txt', 'new content');
+    zip.closeSync();
+
+    const reopened = zlib.ZipFile.openSync(filePath);
+    assert.strictEqual(reopened.getSync('b.txt').contentSync().toString(), 'new content');
+    reopened.closeSync();
+  }
+})().then(common.mustCall());


### PR DESCRIPTION
Adds --vfs=<target>, which mounts a directory or ZIP archive and resolves the entry point (process.argv[1]) and all subsequent require()/import resolution against it instead of the real filesystem. A directory target is mounted with RealFSProvider at its own real path, gaining path containment it wouldn't otherwise have; a file target is opened as a read-only ZIP archive (zlib.ZipFile) and mounted with ArchiveProvider, turning that path into a virtual directory. Only paths under the mount are affected - the running program's own node:fs calls to other real paths are untouched, and module resolution never falls back to the real filesystem once it would step outside the mounted target.

Getting there requires four of the CJS/ESM loader's module-resolution primitives - package.json reading, nearest-parent/scope lookup, legacy main resolution, and extensionless-file format sniffing - to stop bypassing the public fs module and calling straight into native bindings, since that bypass is exactly what let them ignore the mount. Each gets a VFS-aware replacement that defers to the real native binding unchanged for anything outside an active mount, so behavior for non-mounted paths is identical to before.

Native addons are supported: a directory-backed mount dlopens the real underlying file directly; an archive-backed mount extracts the addon to a content-hashed temp file first, since there's no real file to point at. Worker threads inherit an active mount automatically in the common case, and explicitly when the caller supplies its own execArgv that omits it, so sandboxed code can't spawn an "escaped" worker.

Also adds --vfs-manifest=<file>, used with a directory --vfs target: the path of every file actually read through the mount - by module resolution or by the program's own node:fs calls - is appended to <file> as it's read, via a small observer hook on the provider base class rather than patching any method. Workers append to the same file directly, since they share the real filesystem with the main thread.
