### PR TITLE
zlib: add ZipEntry, ZipFile, and ZipBuffer

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -3674,6 +3674,50 @@ All attempts at serializing an uncaught exception from a worker thread failed.
 
 The requested functionality is not supported in worker threads.
 
+<a id="ERR_ZIP_ENTRY_CORRUPT"></a>
+
+### `ERR_ZIP_ENTRY_CORRUPT`
+
+A ZIP archive entry failed CRC-32 verification, or produced more or fewer
+bytes than its declared uncompressed size, while being read.
+
+<a id="ERR_ZIP_ENTRY_NOT_FOUND"></a>
+
+### `ERR_ZIP_ENTRY_NOT_FOUND`
+
+A named entry was requested from a [`ZipFile`][] or [`ZipBuffer`][] that does
+not contain an entry with that name.
+
+<a id="ERR_ZIP_ENTRY_TOO_LARGE"></a>
+
+### `ERR_ZIP_ENTRY_TOO_LARGE`
+
+A ZIP archive entry's declared size exceeds the configured limit, or a
+provided entry name or comment exceeds the 65,535-byte encoded length that
+the ZIP format allows.
+
+<a id="ERR_ZIP_INVALID_ARCHIVE"></a>
+
+### `ERR_ZIP_INVALID_ARCHIVE`
+
+Data that was expected to be a ZIP archive, or a structure within one, is
+missing, out of bounds, or otherwise inconsistent with the ZIP format.
+
+<a id="ERR_ZIP_NOT_WRITABLE"></a>
+
+### `ERR_ZIP_NOT_WRITABLE`
+
+A mutating method (such as `zipFile.addEntry()` or `zipFile.delete()`) was
+called on a [`ZipFile`][] that was not opened with `{ writable: true }`.
+
+<a id="ERR_ZIP_UNSUPPORTED_FEATURE"></a>
+
+### `ERR_ZIP_UNSUPPORTED_FEATURE`
+
+A ZIP archive uses a feature outside of what this implementation supports,
+such as entry encryption, an unsupported compression method, or a multi-disk
+archive.
+
 <a id="ERR_ZLIB_INITIALIZATION_FAILED"></a>
 
 ### `ERR_ZLIB_INITIALIZATION_FAILED`
@@ -4617,6 +4661,8 @@ An error occurred trying to allocate memory. This should never happen.
 [`ServerResponse`]: http.md#class-httpserverresponse
 [`Temporal`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal
 [`Writable`]: stream.md#class-streamwritable
+[`ZipBuffer`]: zlib.md#class-zlibzipbuffer
+[`ZipFile`]: zlib.md#class-zlibzipfile
 [`child_process`]: child_process.md
 [`cipher.getAuthTag()`]: crypto.md#ciphergetauthtag
 [`crypto.getDiffieHellman()`]: crypto.md#cryptogetdiffiehellmangroupname

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -1006,6 +1006,945 @@ added: v0.5.8
 Decompress either a Gzip- or Deflate-compressed stream by auto-detecting
 the header.
 
+## Class: `zlib.ZipBuffer`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+An in-memory, **zero-copy** view over the entries of a ZIP archive already
+held in a `Buffer`, `TypedArray`, `DataView`, or `ArrayBuffer`. Its set of
+entries can be edited - entries added or removed - but, unlike [`ZipFile`][],
+those edits are **not** written into the source buffer: a newly added entry is
+held as a separate in-memory [`ZipEntry`][] (the passed buffer is a fixed-size
+view with no room to append to), and removal just drops the entry from
+`ZipBuffer`'s index. The original bytes are never modified.
+[`zipBuffer.toBuffer()`][] serializes the current set of entries into a fresh
+archive.
+
+`ZipBuffer` does not copy the archive you hand it. It keeps a view onto that
+memory and reads each entry's content lazily and directly from it, which is
+what makes construction cheap regardless of archive size. The trade-off is
+that you **must not modify or reuse** that memory - including the
+`ArrayBuffer` backing a `TypedArray`/`DataView` - while the `ZipBuffer`, or
+any [`ZipEntry`][] obtained from it, is still in use: a later read would
+observe the change and may fail or return corrupt data. Pass a copy (for
+example `Buffer.from(source)`) if the source might be mutated or reused.
+
+`add()` and `toBuffer()` each have a `*Sync` counterpart
+([`addSync()`][`zipBuffer.addSync()`], [`toBufferSync()`][`zipBuffer.toBufferSync()`])
+that performs the same compression work synchronously. As with the
+synchronous `node:fs` APIs, these block the Node.js event loop and further
+JavaScript execution until the operation completes; use them only where
+synchronous execution is appropriate (for example, short-lived scripts or
+startup code), not in code that must stay responsive.
+
+```mjs
+import { ZipBuffer } from 'node:zlib';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { Buffer } from 'node:buffer';
+
+const zip = new ZipBuffer(readFileSync('archive.zip'));
+for (const [name, entry] of zip) {
+  console.log(name, entry.size);
+}
+await zip.add('hello.txt', Buffer.from('Hello, world!'));
+zip.delete('unwanted.txt');
+writeFileSync('archive.zip', await zip.toBuffer());
+```
+
+```cjs
+const { ZipBuffer } = require('node:zlib');
+const { readFileSync, writeFileSync } = require('node:fs');
+
+async function main() {
+  const zip = new ZipBuffer(readFileSync('archive.zip'));
+  for (const [name, entry] of zip) {
+    console.log(name, entry.size);
+  }
+  await zip.add('hello.txt', Buffer.from('Hello, world!'));
+  zip.delete('unwanted.txt');
+  writeFileSync('archive.zip', await zip.toBuffer());
+}
+main();
+```
+
+### `new zlib.ZipBuffer(buffer)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `buffer` {Buffer|TypedArray|DataView|ArrayBuffer} A complete ZIP archive.
+
+Parses the archive's central directory. Throws an [`ERR_ZIP_INVALID_ARCHIVE`][]
+or [`ERR_ZIP_UNSUPPORTED_FEATURE`][] error if `buffer` is not a well-formed,
+supported archive.
+
+`buffer` is **not copied**: the `ZipBuffer` retains a zero-copy view of it (for
+a `TypedArray`, `DataView`, or `ArrayBuffer`, of the underlying `ArrayBuffer`)
+and reads entry content directly from it on demand. Do not mutate or reuse that
+memory while the `ZipBuffer` or any entry read from it is still live; pass a
+copy if it might change.
+
+### `zipBuffer.add(filename, data[, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `filename` {string} The entry's name within the archive. A trailing `/`
+  marks a directory entry.
+* `data` {Buffer|TypedArray|DataView|ArrayBuffer} The entry's complete,
+  uncompressed content.
+* `options` {Object} See [`zlib.ZipEntry.create()`][].
+* Returns: {Promise} Fulfilled with the created {ZipEntry}.
+
+Equivalent to `zipBuffer.addEntry(await zlib.ZipEntry.create(filename, data,
+options))`.
+
+### `zipBuffer.addSync(filename, data[, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `filename` {string} The entry's name within the archive. A trailing `/`
+  marks a directory entry.
+* `data` {Buffer|TypedArray|DataView|ArrayBuffer} The entry's complete,
+  uncompressed content.
+* `options` {Object} See [`zlib.ZipEntry.createSync()`][].
+* Returns: {ZipEntry} The created entry.
+
+The synchronous version of [`zipBuffer.add()`][]. Equivalent to
+`zipBuffer.addEntry(zlib.ZipEntry.createSync(filename, data, options))`.
+
+### `zipBuffer.addEntry(entry)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `entry` {ZipEntry}
+* Returns: {ZipEntry} `entry`.
+
+Adds an already-built entry, keyed by its own [`zipEntry.name`][]. Replaces
+any existing entry of that name.
+
+### `zipBuffer.clear()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Removes every entry.
+
+### `zipBuffer.comment`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string}
+
+The archive-level comment, preserved across [`zipBuffer.toBuffer()`][] calls
+unless overridden.
+
+### `zipBuffer.delete(name)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `name` {string}
+* Returns: {boolean} `true` if an entry named `name` existed and was removed.
+
+### `zipBuffer.entries()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {Iterator} of `[name, entry]` pairs, where `entry` is a
+  [`ZipEntry`][].
+
+### `zipBuffer.forEach(callback[, thisArg])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `callback` {Function}
+* `thisArg` {any}
+
+Calls `callback` once for each entry, in the order the archive lists them.
+
+### `zipBuffer.get(name)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `name` {string}
+* Returns: {ZipEntry}
+
+Throws [`ERR_ZIP_ENTRY_NOT_FOUND`][] if the archive has no entry named `name`.
+
+### `zipBuffer.has(name)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `name` {string}
+* Returns: {boolean}
+
+### `zipBuffer.keys()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {Iterator} of entry names.
+
+### `zipBuffer.size`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {number}
+
+The number of entries in the archive.
+
+### `zipBuffer.toBuffer([options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `options` {string|Object} An archive comment, as a shorthand for
+  `{ comment: options }`.
+  * `comment` {string} An archive comment. **Default:** [`zipBuffer.comment`][].
+  * `baseOffset` {number} Shifts every offset the archive records by this
+    many bytes, so the serialized archive is self-describing even when it is
+    written somewhere other than the start of its eventual file - for example,
+    after `baseOffset` bytes of other content already written to the same
+    output. **Default:** `0`.
+* Returns: {Promise} Fulfilled with a {Buffer} containing the serialized
+  archive.
+
+Serializes the current set of entries - in the order they were added or
+read - into a fresh archive, switching to Zip64 structures automatically as
+needed (see [`zlib.createZipArchive()`][]).
+
+### `zipBuffer.toBufferSync([options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `options` {string|Object} See [`zipBuffer.toBuffer()`][].
+* Returns: {Buffer} The serialized archive.
+
+The synchronous version of [`zipBuffer.toBuffer()`][] (see
+[`zlib.createZipArchiveSync()`][]).
+
+### `zipBuffer.values()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {Iterator} of [`ZipEntry`][].
+
+### `zipBuffer.writable`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {boolean}
+
+Always `true`.
+
+## Class: `zlib.ZipEntry`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+A single file or directory inside a ZIP archive. Instances are produced by
+[`ZipBuffer`][] and [`ZipFile`][], or created directly for writing with
+`ZipEntry.create()`/`ZipEntry.createStream()`.
+
+`create()` and `content()` each have a `*Sync` counterpart (the streaming
+`contentIterator()` does not). As with the synchronous `node:fs` APIs, these
+block the
+Node.js event loop and further JavaScript execution until the operation
+(including any deflate/inflate pass) completes; use them only where
+synchronous execution is appropriate (for example, short-lived scripts or
+startup code), not in code that must stay responsive.
+
+### Static method: `zlib.ZipEntry.create(filename, data[, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `filename` {string} The entry's name within the archive. A trailing `/`
+  marks a directory entry.
+* `data` {Buffer|TypedArray|DataView|ArrayBuffer} The entry's complete,
+  uncompressed content. Must be empty when `filename` names a directory.
+* `options` {Object}
+  * `comment` {string} An entry comment.
+  * `mode` {integer} Unix permission bits. **Default:** `0o644` (`0o755` for
+    directories).
+  * `modified` {Date} The entry's modification time. **Default:** the
+    current time.
+  * `method` {string} One of `'deflate'`, `'store'`, or `'zstd'`. **Default:**
+    `'deflate'`, except for directories and empty content, which are always
+    stored.
+* Returns: {Promise} Fulfilled with a {ZipEntry}.
+
+Compresses `data` (unless `method` is `'store'`, or compression would not
+reduce its size) and computes its CRC-32.
+
+### Static method: `zlib.ZipEntry.createStream(filename, source[, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `filename` {string} The entry's name within the archive. Must not end
+  in `/`.
+* `source` {AsyncIterable} Yields the entry's uncompressed content as
+  `Uint8Array` chunks.
+* `options` {Object}
+  * `comment` {string} An entry comment.
+  * `mode` {integer} Unix permission bits. **Default:** `0o644`.
+  * `modified` {Date} The entry's modification time. **Default:** the
+    current time.
+  * `method` {string} One of `'deflate'`, `'store'`, or `'zstd'`. **Default:**
+    `'deflate'`.
+* Returns: {ZipEntry}
+
+Creates an entry whose content is compressed on the fly as it is serialized
+by [`zlib.createZipArchive()`][], without buffering `source` in memory. Its
+`size`, `compressedSize`, and `crc32` only become available once
+serialization has finished. There is no synchronous counterpart: streaming
+entries only make sense with an asynchronous, incrementally-produced
+`source`.
+
+`source` is drained exactly once, during serialization. Until that happens
+the entry has no readable content, so [`zipEntry.content()`][],
+[`zipEntry.contentSync()`][], and [`zipEntry.contentIterator()`][] throw
+[`ERR_INVALID_STATE`][]. If the entry is serialized by adding it to a writable
+[`ZipFile`][] with [`zipFile.addEntry()`][] (or `addEntrySync()`), it is then
+**promoted in place** to a file-backed entry pointing at the copy just written,
+so it becomes readable (and can be serialized again) for as long as that
+`ZipFile` stays open. Serializing it any other way (for example directly
+through [`zlib.createZipArchive()`][]) leaves it spent and unreadable.
+
+### Static method: `zlib.ZipEntry.createSync(filename, data[, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `filename` {string} The entry's name within the archive. A trailing `/`
+  marks a directory entry.
+* `data` {Buffer|TypedArray|DataView|ArrayBuffer} The entry's complete,
+  uncompressed content. Must be empty when `filename` names a directory.
+* `options` {Object} See [`zlib.ZipEntry.create()`][].
+* Returns: {ZipEntry}
+
+The synchronous version of [`zlib.ZipEntry.create()`][].
+
+### Static method: `zlib.ZipEntry.read(buffer)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `buffer` {Buffer|TypedArray|DataView|ArrayBuffer} A complete ZIP archive.
+* Returns: {Iterator} of {ZipEntry}.
+
+Parses every entry out of `buffer` directly, without indexing it into a
+[`ZipBuffer`][]. Like [`ZipBuffer`][], the yielded entries hold zero-copy views
+of `buffer` rather than copies of their content, so the same rule applies: do
+not mutate or reuse `buffer` while any of them is still in use.
+
+### `zipEntry.comment`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string}
+
+### `zipEntry.compressed`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {boolean}
+
+`true` if the entry uses the deflate compression method.
+
+### `zipEntry.compressedSize`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {number}
+
+### `zipEntry.content([options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `options` {Object}
+  * `verify` {boolean} Verify the entry's CRC-32 checksum. **Default:** `true`.
+  * `maxSize` {number} Reject content declaring more than this many
+    uncompressed bytes, before allocating anything. **Default:**
+    [`zlib.getMaxZipContentSize()`][].
+* Returns: {Promise} Fulfilled with a {Buffer} containing the entry's
+  decompressed content.
+
+Throws an [`ERR_ZIP_ENTRY_TOO_LARGE`][] error if the entry's declared size
+exceeds `maxSize`, an [`ERR_ZIP_ENTRY_CORRUPT`][] error if the content fails
+CRC-32 verification or does not match its declared size, and an
+[`ERR_INVALID_STATE`][] error for a streaming entry
+([`zlib.ZipEntry.createStream()`][]) whose content is not yet available (see
+that method for when a streaming entry becomes readable).
+
+### `zipEntry.contentSync([options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `options` {Object} See [`zipEntry.content()`][].
+* Returns: {Buffer} The entry's decompressed content.
+
+The synchronous version of [`zipEntry.content()`][].
+
+### `zipEntry.contentIterator([options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `options` {Object}
+  * `verify` {boolean} Verify the entry's CRC-32 checksum. **Default:** `true`.
+  * `maxSize` {number} Reject content declaring more than this many
+    uncompressed bytes. **Default:** no limit.
+* Returns: {AsyncIterator} of {Buffer} chunks of the entry's decompressed
+  content.
+
+Unlike [`zipEntry.content()`][], this does not buffer the whole member in
+memory. For a file-backed entry (one returned by [`zipFile.get()`][]) the
+compressed bytes are read from disk as the iterator is consumed and nothing is
+retained; the entry is valid only while its `ZipFile` is open.
+
+### `zipEntry.crc32`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {number}
+
+### `zipEntry.flags`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {number}
+
+The entry's raw general-purpose bit flag.
+
+### `zipEntry.isDirectory`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {boolean}
+
+### `zipEntry.isFile`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {boolean}
+
+### `zipEntry.mode`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {number}
+
+The entry's Unix permission bits, or `0` if the archive was not written on
+a Unix-like system.
+
+### `zipEntry.modified`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {Date}
+
+### `zipEntry.method`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {number}
+
+The entry's raw compression method: `0` for stored, `8` for deflate, `93`
+for Zstandard.
+
+### `zipEntry.name`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string}
+
+### `zipEntry.rawContent`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {Buffer|null}
+
+The entry's raw (still compressed, if applicable) content when it is held in
+memory, or `null` when there is no in-memory buffer to expose - for an entry
+created with [`zlib.ZipEntry.createStream()`][], or a file-backed entry
+returned by [`zipFile.get()`][], whose bytes are read from disk on demand
+rather than retained. Use [`zipEntry.content()`][] or
+[`zipEntry.contentIterator()`][] to read a file-backed entry.
+
+### `zipEntry.size`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {number}
+
+The entry's uncompressed size, in bytes.
+
+## Class: `zlib.ZipFile`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+A random-access view over the entries of a ZIP archive on disk. Only the
+archive's tail and central directory are read up front; member content is
+read from disk lazily, on demand. Writable when opened with
+`{ writable: true }`: [`zipFile.addEntry()`][]/[`zipFile.add()`][] append the
+new member's data where the central directory used to be, then rewrite the
+central directory immediately after it; [`zipFile.delete()`][] just rewrites
+the central directory. Both mean the file is altered as soon as the method's
+returned `Promise` fulfills. Deleted or replaced members are left behind as
+dead space; [`zipFile.compact()`][] produces a stream with none.
+
+Every method has a `*Sync` counterpart. As with the synchronous `node:fs`
+APIs, these block the Node.js event loop and further JavaScript execution
+until the operation completes; use them only where synchronous execution is
+appropriate (for example, short-lived scripts or startup code), not in code
+that must stay responsive. A synchronous method throws `ERR_INVALID_STATE`
+if called while an asynchronous `add()`, `addEntry()`, `delete()`, or
+`close()` on the same `ZipFile` has not settled yet, since letting the two
+interleave could corrupt the archive.
+
+```mjs
+import { ZipFile } from 'node:zlib';
+import { Buffer } from 'node:buffer';
+
+const zip = await ZipFile.open('archive.zip', { writable: true });
+try {
+  const entry = await zip.get('member.txt');
+  console.log((await entry.content()).toString());
+  for await (const chunk of zip.stream('huge.bin')) {
+    // Process each chunk without buffering the whole member.
+  }
+  await zip.add('new.txt', Buffer.from('hello'));
+  await zip.delete('unwanted.txt');
+} finally {
+  await zip.close();
+}
+```
+
+```cjs
+const { ZipFile } = require('node:zlib');
+
+async function main() {
+  const zip = await ZipFile.open('archive.zip', { writable: true });
+  try {
+    const entry = await zip.get('member.txt');
+    console.log((await entry.content()).toString());
+    for await (const chunk of zip.stream('huge.bin')) {
+      // Process each chunk without buffering the whole member.
+    }
+    await zip.add('new.txt', Buffer.from('hello'));
+    await zip.delete('unwanted.txt');
+  } finally {
+    await zip.close();
+  }
+}
+main();
+```
+
+### Static method: `zlib.ZipFile.open(filename[, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `filename` {string}
+* `options` {Object}
+  * `writable` {boolean} Open the underlying file for both reading and
+    writing (`'r+'`), enabling [`zipFile.addEntry()`][]/[`zipFile.add()`][]/
+    [`zipFile.delete()`][]. **Default:** `false`.
+* Returns: {Promise} Fulfilled with a {ZipFile}.
+
+### Static method: `zlib.ZipFile.openSync(filename[, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `filename` {string}
+* `options` {Object} See [`zlib.ZipFile.open()`][].
+* Returns: {ZipFile}
+
+The synchronous version of [`zlib.ZipFile.open()`][].
+
+### `zipFile.add(filename, data[, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `filename` {string} The entry's name within the archive. A trailing `/`
+  marks a directory entry.
+* `data` {Buffer|TypedArray|DataView|ArrayBuffer} The entry's complete,
+  uncompressed content.
+* `options` {Object} See [`zlib.ZipEntry.create()`][].
+* Returns: {Promise} Fulfilled with the created {ZipEntry}.
+
+Equivalent to `zipFile.addEntry(await zlib.ZipEntry.create(filename, data,
+options))`.
+
+### `zipFile.addEntry(entry)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `entry` {ZipEntry}
+* Returns: {Promise} Fulfilled with `entry`.
+
+Writes `entry` where the central directory currently starts, then rewrites
+the central directory to include it, replacing any existing entry of the
+same name. Throws [`ERR_ZIP_NOT_WRITABLE`][] if the `ZipFile` was not opened
+with `{ writable: true }`.
+
+The returned (same) `entry` is left readable: a streaming entry created with
+[`zlib.ZipEntry.createStream()`][], which would otherwise be spent once
+serialized, is promoted in place to a file-backed entry pointing at the copy
+just written (valid while this `ZipFile` is open). In-memory entries keep their
+own buffer unchanged.
+
+### `zipFile.addEntrySync(entry)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `entry` {ZipEntry}
+* Returns: {ZipEntry} `entry`.
+
+The synchronous version of [`zipFile.addEntry()`][]. `entry` must not be a
+pending streaming entry (one created with
+[`zlib.ZipEntry.createStream()`][]) - there is no synchronous way to drain
+its asynchronous source.
+
+### `zipFile.addSync(filename, data[, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `filename` {string} The entry's name within the archive. A trailing `/`
+  marks a directory entry.
+* `data` {Buffer|TypedArray|DataView|ArrayBuffer} The entry's complete,
+  uncompressed content.
+* `options` {Object} See [`zlib.ZipEntry.createSync()`][].
+* Returns: {ZipEntry} The created entry.
+
+The synchronous version of [`zipFile.add()`][]. Equivalent to
+`zipFile.addEntrySync(zlib.ZipEntry.createSync(filename, data, options))`.
+
+### `zipFile.close()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {Promise}
+
+Closes the underlying file handle.
+
+### `zipFile.closeSync()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+The synchronous version of [`zipFile.close()`][].
+
+### `zipFile.comment`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string}
+
+The archive-level comment, preserved across [`zipFile.addEntry()`][]/
+[`zipFile.delete()`][] calls.
+
+### `zipFile.compact([comment])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `comment` {string} An archive comment. **Default:** [`zipFile.comment`][].
+* Returns: {stream.Readable} A stream of the currently live entries,
+  serialized as a fresh archive with no dead space left by prior
+  [`zipFile.addEntry()`][]/[`zipFile.delete()`][] calls.
+
+Does not modify the open file; pipe the result into a new one:
+
+```mjs
+import { createWriteStream } from 'node:fs';
+zip.compact().pipe(createWriteStream('compacted.zip'));
+```
+
+### `zipFile.compactSync([comment])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `comment` {string} An archive comment. **Default:** [`zipFile.comment`][].
+* Returns: {Buffer} The currently live entries, serialized as a fresh
+  archive with no dead space left by prior
+  [`zipFile.addEntry()`][]/[`zipFile.delete()`][] calls.
+
+The synchronous version of [`zipFile.compact()`][]. Does not modify the
+open file.
+
+### `zipFile.delete(name)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `name` {string}
+* Returns: {Promise} Fulfilled with `true` if an entry named `name` existed
+  and was removed, `false` otherwise.
+
+Rewrites the central directory without writing any new content - the
+archive does not grow. Throws [`ERR_ZIP_NOT_WRITABLE`][] if the `ZipFile` was
+not opened with `{ writable: true }`.
+
+### `zipFile.deleteSync(name)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `name` {string}
+* Returns: {boolean} `true` if an entry named `name` existed and was
+  removed, `false` otherwise.
+
+The synchronous version of [`zipFile.delete()`][].
+
+### `zipFile.entries()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {Iterator} of `[name, entry]` pairs, where `entry` is a
+  {Promise} fulfilled with a [`ZipEntry`][].
+
+### `zipFile.entriesSync()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {Iterator} of `[name, entry]` pairs, where `entry` is a resolved
+  [`ZipEntry`][] (not a `Promise`).
+
+The synchronous version of [`zipFile.entries()`][].
+
+### `zipFile.forEach(callback[, thisArg])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `callback` {Function}
+* `thisArg` {any}
+
+### `zipFile.forEachSync(callback[, thisArg])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `callback` {Function}
+* `thisArg` {any}
+
+The synchronous version of [`zipFile.forEach()`][]: `callback` is invoked
+with a resolved [`ZipEntry`][] instead of a `Promise`.
+
+### `zipFile.get(name)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `name` {string}
+* Returns: {Promise} Fulfilled with a {ZipEntry}.
+
+Returns a lazy, file-backed [`ZipEntry`][] for `name`. Nothing is read from
+disk here and no content is buffered: the returned entry reads (and, for
+[`zipEntry.content()`][], decompresses) its member straight from the file on
+each access, and the `ZipFile` retains no member content. The entry is valid
+only while this `ZipFile` is open. Reading its content later may throw
+[`ERR_ZIP_ENTRY_TOO_LARGE`][] if the member is too large to hold in a single
+buffer; use [`zipEntry.contentIterator()`][] (or [`zipFile.stream()`][])
+instead. Throws [`ERR_ZIP_ENTRY_NOT_FOUND`][] if the archive has no entry
+named `name`.
+
+### `zipFile.getSync(name)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `name` {string}
+* Returns: {ZipEntry}
+
+The synchronous version of [`zipFile.get()`][]. Like `get()`, it reads
+nothing up front and only builds the lazy handle, so it does not itself block
+on I/O - but reads performed later through the returned entry (such as
+[`zipEntry.contentSync()`][]) do; see the note above on synchronous methods.
+
+### `zipFile.has(name)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `name` {string}
+* Returns: {boolean}
+
+### `zipFile.keys()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {Iterator} of entry names.
+
+### `zipFile.size`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {number}
+
+The number of entries in the archive.
+
+### `zipFile.stream(name[, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `name` {string}
+* `options` {Object}
+  * `verify` {boolean} Verify the entry's CRC-32 checksum. **Default:** `true`.
+  * `maxSize` {number} Reject content declaring more than this many
+    uncompressed bytes. **Default:** no limit.
+* Returns: {Promise} Fulfilled with a {stream.Readable} of the member's
+  decompressed content, without buffering the whole member in memory.
+
+Convenience wrapper that resolves to a `Readable` over
+[`zipEntry.contentIterator()`][] of [`zipFile.get()`][]`(name)`; the
+compressed bytes are read from disk as the stream is consumed. The returned
+promise rejects with [`ERR_ZIP_ENTRY_NOT_FOUND`][] if the archive has no entry
+named `name`.
+
+### `zipFile.values()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {Iterator} of {Promise} objects, each fulfilled with a
+  [`ZipEntry`][].
+
+### `zipFile.valuesSync()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {Iterator} of resolved [`ZipEntry`][] values (not `Promise`s).
+
+The synchronous version of [`zipFile.values()`][].
+
+### `zipFile.writable`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {boolean}
+
+Whether this `ZipFile` was opened with `{ writable: true }`.
+
 ## Class: `zlib.ZlibBase`
 
 <!-- YAML
@@ -1330,6 +2269,101 @@ added: v0.5.8
 
 Creates and returns a new [`Unzip`][] object.
 
+## `zlib.createZipArchive(entries[, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `entries` {Iterable|AsyncIterable} of [`ZipEntry`][].
+* `options` {string|Object} An archive comment, as a shorthand for
+  `{ comment: options }`.
+  * `comment` {string} An archive comment.
+  * `baseOffset` {number} Shifts every local/central header offset the
+    archive records by this many bytes, so the emitted stream is
+    self-describing even when something else is written before it - for
+    example, appending the archive after `baseOffset` bytes already written to
+    the same file, rather than at its start. **Default:** `0`.
+* Returns: {stream.Readable} A byte stream of the serialized archive.
+
+Serializes `entries` into a ZIP archive, switching to Zip64 structures
+automatically once the entry count, or any offset or size, exceeds what the
+classic 32-/16-bit ZIP fields can hold. The returned `Readable` is also an
+`AsyncIterable` of the same {Buffer} chunks it streams.
+
+```mjs
+import { createWriteStream } from 'node:fs';
+import { pipeline } from 'node:stream/promises';
+import { Buffer } from 'node:buffer';
+import { ZipEntry, createZipArchive } from 'node:zlib';
+
+const entries = [
+  await ZipEntry.create('hello.txt', Buffer.from('Hello, world!')),
+  await ZipEntry.create('data/', Buffer.alloc(0)),
+];
+await pipeline(
+  createZipArchive(entries, 'created by node:zlib'),
+  createWriteStream('archive.zip'),
+);
+```
+
+```cjs
+const { createWriteStream } = require('node:fs');
+const { pipeline } = require('node:stream/promises');
+const { ZipEntry, createZipArchive } = require('node:zlib');
+
+async function main() {
+  const entries = [
+    await ZipEntry.create('hello.txt', Buffer.from('Hello, world!')),
+    await ZipEntry.create('data/', Buffer.alloc(0)),
+  ];
+  await pipeline(
+    createZipArchive(entries, 'created by node:zlib'),
+    createWriteStream('archive.zip'),
+  );
+}
+main();
+```
+
+Passing `options.baseOffset` produces an archive that is valid immediately
+when placed after other content in the same file, without relying on a
+reader's self-extracting-archive detection to compensate for the shift:
+
+```mjs
+import { createWriteStream } from 'node:fs';
+import { Buffer } from 'node:buffer';
+import { ZipEntry, createZipArchive } from 'node:zlib';
+
+const prefix = Buffer.from('#!/bin/sh\nexit 0\n');
+const entries = [await ZipEntry.create('hello.txt', Buffer.from('Hello, world!'))];
+const out = createWriteStream('self-extracting.zip');
+out.write(prefix);
+createZipArchive(entries, { baseOffset: prefix.byteLength }).pipe(out);
+```
+
+## `zlib.createZipArchiveSync(entries[, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `entries` {Iterable} of [`ZipEntry`][].
+* `options` {string|Object} See [`zlib.createZipArchive()`][].
+* Returns: {Iterator} of {Buffer} chunks making up the serialized archive.
+
+The synchronous version of [`zlib.createZipArchive()`][]. Blocks the
+Node.js event loop and further JavaScript execution until the whole
+archive (including any deflate passes) has been produced; use only where
+synchronous execution is appropriate (for example, short-lived scripts or
+startup code), not in code that must stay responsive. `entries` must be a
+plain (synchronous) `Iterable` - a streaming entry created with
+[`zlib.ZipEntry.createStream()`][] throws when its turn to serialize comes
+up, since draining its asynchronous source has no synchronous equivalent.
+
 ## `zlib.createZstdCompress([options])`
 
 > Stability: 1 - Experimental
@@ -1357,6 +2391,36 @@ added:
 * `options` {zstd options}
 
 Creates and returns a new [`ZstdDecompress`][] object.
+
+## `zlib.getMaxZipContentSize()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* Returns: {number}
+
+The current default ceiling, in bytes, applied by [`zipEntry.content()`][]
+when no explicit `maxSize` is given. **Default:** `268435456` (256 MiB).
+
+## `zlib.setMaxZipContentSize(size)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `size` {number}
+
+Sets the default ceiling used by [`zipEntry.content()`][] when no explicit
+`maxSize` option is given. This is a guard against zip bombs: an archive
+whose central directory declares a member larger than this is rejected
+before allocating memory for it. Streaming reads
+([`zipEntry.contentIterator()`][], [`zipFile.stream()`][]) are bounded-memory
+by design and are not affected by this setting.
 
 ## Convenience methods
 
@@ -2023,11 +3087,21 @@ Create a Zstandard decompression transform.
 [`Content-Encoding`]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11
 [`DeflateRaw`]: #class-zlibdeflateraw
 [`Deflate`]: #class-zlibdeflate
+[`ERR_INVALID_STATE`]: errors.md#err_invalid_state
+[`ERR_ZIP_ENTRY_CORRUPT`]: errors.md#err_zip_entry_corrupt
+[`ERR_ZIP_ENTRY_NOT_FOUND`]: errors.md#err_zip_entry_not_found
+[`ERR_ZIP_ENTRY_TOO_LARGE`]: errors.md#err_zip_entry_too_large
+[`ERR_ZIP_INVALID_ARCHIVE`]: errors.md#err_zip_invalid_archive
+[`ERR_ZIP_NOT_WRITABLE`]: errors.md#err_zip_not_writable
+[`ERR_ZIP_UNSUPPORTED_FEATURE`]: errors.md#err_zip_unsupported_feature
 [`Gunzip`]: #class-zlibgunzip
 [`Gzip`]: #class-zlibgzip
 [`InflateRaw`]: #class-zlibinflateraw
 [`Inflate`]: #class-zlibinflate
 [`Unzip`]: #class-zlibunzip
+[`ZipBuffer`]: #class-zlibzipbuffer
+[`ZipEntry`]: #class-zlibzipentry
+[`ZipFile`]: #class-zlibzipfile
 [`ZlibBase`]: #class-zlibzlibbase
 [`ZstdCompress`]: #class-zlibzstdcompress
 [`ZstdDecompress`]: #class-zlibzstddecompress
@@ -2037,6 +3111,33 @@ Create a Zstandard decompression transform.
 [`pipeTo()`]: stream_iter.md#pipetosource-transforms-writer-options
 [`pull()`]: stream_iter.md#pullsource-transforms-options
 [`stream.Transform`]: stream.md#class-streamtransform
+[`zipBuffer.add()`]: #zipbufferaddfilename-data-options
+[`zipBuffer.addSync()`]: #zipbufferaddsyncfilename-data-options
+[`zipBuffer.comment`]: #zipbuffercomment
+[`zipBuffer.toBuffer()`]: #zipbuffertobufferoptions
+[`zipBuffer.toBufferSync()`]: #zipbuffertobuffersyncoptions
+[`zipEntry.content()`]: #zipentrycontentoptions
+[`zipEntry.contentIterator()`]: #zipentrycontentiteratoroptions
+[`zipEntry.contentSync()`]: #zipentrycontentsyncoptions
+[`zipEntry.name`]: #zipentryname
+[`zipFile.add()`]: #zipfileaddfilename-data-options
+[`zipFile.addEntry()`]: #zipfileaddentryentry
+[`zipFile.close()`]: #zipfileclose
+[`zipFile.comment`]: #zipfilecomment
+[`zipFile.compact()`]: #zipfilecompactcomment
+[`zipFile.delete()`]: #zipfiledeletename
+[`zipFile.entries()`]: #zipfileentries
+[`zipFile.forEach()`]: #zipfileforeachcallback-thisarg
+[`zipFile.get()`]: #zipfilegetname
+[`zipFile.stream()`]: #zipfilestreamname-options
+[`zipFile.values()`]: #zipfilevalues
+[`zlib.ZipEntry.create()`]: #static-method-zlibzipentrycreatefilename-data-options
+[`zlib.ZipEntry.createStream()`]: #static-method-zlibzipentrycreatestreamfilename-source-options
+[`zlib.ZipEntry.createSync()`]: #static-method-zlibzipentrycreatesyncfilename-data-options
+[`zlib.ZipFile.open()`]: #static-method-zlibzipfileopenfilename-options
+[`zlib.createZipArchive()`]: #zlibcreateziparchiveentries-options
+[`zlib.createZipArchiveSync()`]: #zlibcreateziparchivesyncentries-options
+[`zlib.getMaxZipContentSize()`]: #zlibgetmaxzipcontentsize
 [convenience methods]: #convenience-methods
 [zlib documentation]: https://zlib.net/manual.html#Constants
 [zlib.createGzip example]: #zlib

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -2002,4 +2002,10 @@ E('ERR_WORKER_UNSERIALIZABLE_ERROR',
   'Serializing an uncaught exception failed', Error);
 E('ERR_WORKER_UNSUPPORTED_OPERATION',
   '%s is not supported in workers', TypeError);
+E('ERR_ZIP_ENTRY_CORRUPT', 'ZIP entry is corrupt: %s', Error);
+E('ERR_ZIP_ENTRY_NOT_FOUND', 'no such entry %j in the archive', Error);
+E('ERR_ZIP_ENTRY_TOO_LARGE', 'ZIP entry exceeds the allowed size: %s', RangeError);
+E('ERR_ZIP_INVALID_ARCHIVE', 'invalid ZIP archive: %s', Error);
+E('ERR_ZIP_NOT_WRITABLE', 'this archive was not opened for writing', TypeError);
+E('ERR_ZIP_UNSUPPORTED_FEATURE', 'unsupported ZIP feature: %s', Error);
 E('ERR_ZSTD_INVALID_PARAM', '%s is not a valid zstd parameter', RangeError);

--- a/lib/internal/zip.js
+++ b/lib/internal/zip.js
@@ -1,0 +1,2407 @@
+'use strict';
+
+const {
+  ArrayPrototypePush,
+  BigInt,
+  Date,
+  FunctionPrototypeCall,
+  JSONStringify,
+  Map,
+  MapPrototypeClear,
+  MapPrototypeDelete,
+  MapPrototypeEntries,
+  MapPrototypeGet,
+  MapPrototypeGetSize,
+  MapPrototypeHas,
+  MapPrototypeKeys,
+  MapPrototypeSet,
+  MathMax,
+  MathMin,
+  Number,
+  NumberIsInteger,
+  NumberIsNaN,
+  NumberMAX_SAFE_INTEGER,
+  Promise,
+  PromisePrototypeThen,
+  PromiseResolve,
+  StringPrototypeEndsWith,
+  Symbol,
+  SymbolAsyncDispose,
+  SymbolAsyncIterator,
+  SymbolDispose,
+  SymbolIterator,
+  SymbolToStringTag,
+} = primordials;
+
+const {
+  codes: {
+    ERR_INVALID_ARG_TYPE,
+    ERR_INVALID_ARG_VALUE,
+    ERR_INVALID_STATE,
+    ERR_ZIP_ENTRY_CORRUPT,
+    ERR_ZIP_ENTRY_NOT_FOUND,
+    ERR_ZIP_ENTRY_TOO_LARGE,
+    ERR_ZIP_INVALID_ARCHIVE,
+    ERR_ZIP_NOT_WRITABLE,
+    ERR_ZIP_UNSUPPORTED_FEATURE,
+  },
+} = require('internal/errors');
+const {
+  validateBoolean,
+  validateFunction,
+  validateInteger,
+  validateObject,
+  validateString,
+  validateUint32,
+} = require('internal/validators');
+const {
+  isAnyArrayBuffer,
+  isArrayBufferView,
+  isDate,
+  isUint8Array,
+} = require('internal/util/types');
+const { Buffer, kMaxLength } = require('buffer');
+const { FastBuffer } = require('internal/buffer');
+const { Readable } = require('stream');
+const fs = require('fs');
+const { crc32: crc32Native } = internalBinding('zlib');
+
+// `internal/zip` is required from `lib/zlib.js`, so it must not require the
+// public `zlib` facade at load time (its module.exports is not yet
+// populated). Compression is only needed once an entry is actually read or
+// written, well after `zlib.js` has finished loading, so a lazy reference is
+// enough to break the cycle.
+let zlib;
+function lazyZlib() {
+  zlib ??= require('zlib');
+  return zlib;
+}
+
+const EMPTY_BUFFER = new FastBuffer();
+const BIGINT_MAX_SAFE_INTEGER = BigInt(NumberMAX_SAFE_INTEGER);
+
+// ZIP record signatures (APPNOTE.TXT, PKWARE Inc.)
+const SIG_LOCAL_FILE_HEADER = 0x04034b50; // sec. 4.3.7
+const SIG_DATA_DESCRIPTOR = 0x08074b50; // sec. 4.3.9
+const SIG_CENTRAL_FILE_HEADER = 0x02014b50; // sec. 4.3.12
+const SIG_ZIP64_EOCD_RECORD = 0x06064b50; // sec. 4.3.14
+const SIG_ZIP64_EOCD_LOCATOR = 0x07064b50; // sec. 4.3.15
+const SIG_EOCD = 0x06054b50; // sec. 4.3.16
+
+const MADE_BY_UNIX = 3; // sec. 4.4.2
+const ZIP64_EXTRA_ID = 0x0001; // sec. 4.5.3
+
+const SENTINEL16 = 0xffff;
+const SENTINEL32 = 0xffffffff;
+
+const FLAG_ENCRYPTED = 0x0001; // sec. 4.4.4 bit 0
+const FLAG_DATA_DESCRIPTOR = 0x0008; // bit 3
+const FLAG_UTF8 = 0x0800; // bit 11: name/comment are UTF-8 (EFS)
+
+const METHOD_STORE = 0; // sec. 4.4.5
+const METHOD_DEFLATE = 8; // sec. 4.4.5
+const METHOD_ZSTD = 93; // sec. 4.4.5
+
+const VERSION_DEFAULT = 20; // 2.0: deflate + directories (sec. 4.4.3)
+const VERSION_ZIP64 = 45; // 4.5: Zip64 structures
+
+const S_IFREG = 0o100000; // Unix mode type bits: regular file
+const S_IFDIR = 0o040000; // Unix mode type bits: directory
+
+const kFinalize = Symbol('kFinalize');
+const kPromote = Symbol('kPromote');
+
+// A default ceiling on the uncompressed size that the buffering read paths
+// (`ZipEntry.prototype.content()`, and therefore `ZipBuffer`/`ZipFile`
+// `get()`) will materialize in memory when the caller does not pass an
+// explicit `maxSize`. An archive whose central directory declares a member
+// larger than this is rejected before any large allocation happens. Callers
+// that need larger members can either pass a per-call `maxSize` or raise the
+// module default with `setMaxZipContentSize()`. The streaming read paths
+// (`contentIterator()`, `ZipFile.prototype.stream()`) are bounded-memory by
+// design and are not subject to this default.
+const DEFAULT_MAX_ZIP_CONTENT_SIZE = 256 * 1024 * 1024; // 256 MiB
+let maxZipContentSize = DEFAULT_MAX_ZIP_CONTENT_SIZE;
+
+/**
+ * @returns {number}
+ */
+function getMaxZipContentSize() {
+  return maxZipContentSize;
+}
+
+/**
+ * @param {number} size
+ * @returns {void}
+ */
+function setMaxZipContentSize(size) {
+  validateInteger(size, 'size', 0);
+  maxZipContentSize = size;
+}
+
+// DOS date/time (sec. 4.4.6): local time by convention.
+// time: bits 0-4 seconds/2, 5-10 minutes, 11-15 hours
+// date: bits 0-4 day, 5-8 month, 9-15 years since 1980
+function decodeDosDateTime(time, date) {
+  // A zeroed/absent date field has month 0 and day 0, both invalid; the DOS
+  // epoch is 1980-01-01. Month/day 0 are treated as 1 so a zero field decodes
+  // to 1980-01-01 (and re-encodes to the same value).
+  return new Date(
+    ((date >>> 9) & 0x7f) + 1980,
+    ((date >>> 5) & 0x0f || 1) - 1,
+    (date & 0x1f) || 1,
+    (time >>> 11) & 0x1f,
+    (time >>> 5) & 0x3f,
+    (time & 0x1f) * 2,
+  );
+}
+
+function encodeDosDateTime(value) {
+  const year = value.getFullYear();
+  if (NumberIsNaN(year)) {
+    throw new ERR_INVALID_ARG_VALUE('modified', value, 'must be a valid Date');
+  }
+  if (year < 1980) return { time: 0, date: (1 << 5) | 1 }; // Clamp to 1980-01-01 00:00:00
+  if (year > 2107) {
+    // Clamp to 2107-12-31 23:59:58
+    return {
+      time: (23 << 11) | (59 << 5) | 29,
+      date: (127 << 9) | (12 << 5) | 31,
+    };
+  }
+  const date =
+    ((year - 1980) << 9) | ((value.getMonth() + 1) << 5) | value.getDate();
+  const time =
+    (value.getHours() << 11) |
+    (value.getMinutes() << 5) |
+    (value.getSeconds() >>> 1);
+  return { time, date };
+}
+
+function validateArchiveRange(buffer, offset, length, what) {
+  if (
+    !NumberIsInteger(offset) ||
+    offset < 0 ||
+    !NumberIsInteger(length) ||
+    length < 0 ||
+    offset + length > buffer.length
+  ) {
+    throw new ERR_ZIP_INVALID_ARCHIVE(`${what} is out of bounds`);
+  }
+}
+
+function readSafeUint64(buffer, offset) {
+  if (offset + 8 > buffer.length) {
+    throw new ERR_ZIP_INVALID_ARCHIVE('64-bit field is out of bounds');
+  }
+  const value = buffer.readBigUInt64LE(offset);
+  if (value > BIGINT_MAX_SAFE_INTEGER) {
+    throw new ERR_ZIP_INVALID_ARCHIVE('64-bit field exceeds the safe integer range');
+  }
+  return Number(value);
+}
+
+function writeSafeUint64(buffer, offset, value) {
+  buffer.writeBigUInt64LE(BigInt(value), offset);
+}
+
+// Zip64 extended information extra field (sec. 4.5.3).
+function parseZip64Extra(extra, want) {
+  const wanted =
+    want.uncompressedSize ||
+    want.compressedSize ||
+    want.localFileHeaderOffset ||
+    want.diskNumber;
+  if (!wanted) return {};
+  let pos = 0;
+  while (pos + 4 <= extra.length) {
+    const id = extra.readUInt16LE(pos);
+    const size = extra.readUInt16LE(pos + 2);
+    if (pos + 4 + size > extra.length) {
+      throw new ERR_ZIP_INVALID_ARCHIVE('extra field is malformed');
+    }
+    if (id === ZIP64_EXTRA_ID) {
+      const result = {};
+      let cursor = pos + 4;
+      const end = pos + 4 + size;
+      const take = (bytes) => {
+        if (cursor + bytes > end) {
+          throw new ERR_ZIP_INVALID_ARCHIVE(
+            'the Zip64 extended information extra field is truncated');
+        }
+        const value = bytes === 8 ?
+          readSafeUint64(extra, cursor) : extra.readUInt32LE(cursor);
+        cursor += bytes;
+        return value;
+      };
+      if (want.uncompressedSize) result.uncompressedSize = take(8);
+      if (want.compressedSize) result.compressedSize = take(8);
+      if (want.localFileHeaderOffset) result.localFileHeaderOffset = take(8);
+      if (want.diskNumber) result.diskNumber = take(4);
+      return result;
+    }
+    pos += 4 + size;
+  }
+  throw new ERR_ZIP_INVALID_ARCHIVE(
+    'a field is 0xFFFFFFFF but the Zip64 extended information extra field is missing');
+}
+
+// End of central directory record (sec. 4.3.16).
+// Offset   Bytes   Description
+// 0        4       Signature = 0x06054b50
+// 4        2       Number of this disk
+// 6        2       Disk where central directory starts
+// 8        2       Number of central directory records on this disk
+// 10       2       Total number of central directory records
+// 12       4       Size of central directory (bytes)
+// 16       4       Offset of start of central directory
+// 20       2       Comment length (n)
+// 22       n       Comment
+class CentralEndHeader {
+  #buffer;
+  #offset;
+  constructor(buffer, offset = 0) {
+    validateArchiveRange(buffer, offset, 22, 'end of central directory record');
+    if (buffer.readUInt32LE(offset) !== SIG_EOCD) {
+      throw new ERR_ZIP_INVALID_ARCHIVE('end of central directory signature is invalid');
+    }
+    this.#buffer = buffer;
+    this.#offset = offset;
+    if (offset + this.byteLength > buffer.length) {
+      throw new ERR_ZIP_INVALID_ARCHIVE('end of central directory record is truncated');
+    }
+  }
+  get byteLength() { return 22 + this.commentLength; }
+  get diskNumber() { return this.#buffer.readUInt16LE(this.#offset + 4); }
+  get centralDirectoryDiskNumber() { return this.#buffer.readUInt16LE(this.#offset + 6); }
+  get centralDirectoryDiskRecords() { return this.#buffer.readUInt16LE(this.#offset + 8); }
+  get centralDirectoryTotalRecords() { return this.#buffer.readUInt16LE(this.#offset + 10); }
+  get centralDirectorySize() { return this.#buffer.readUInt32LE(this.#offset + 12); }
+  get centralDirectoryOffset() { return this.#buffer.readUInt32LE(this.#offset + 16); }
+  get commentLength() { return this.#buffer.readUInt16LE(this.#offset + 20); }
+  get commentBuffer() {
+    const start = this.#offset + 22;
+    return this.#buffer.subarray(start, start + this.commentLength);
+  }
+}
+
+// Zip64 end of central directory record (sec. 4.3.14).
+// 0    4   Signature = 0x06064b50
+// 4    8   Size of remainder of this record
+// 12   2   Version made by
+// 14   2   Version needed to extract
+// 16   4   Number of this disk
+// 20   4   Disk where central directory starts
+// 24   8   Number of central directory records on this disk
+// 32   8   Total number of central directory records
+// 40   8   Size of central directory
+// 48   8   Offset of start of central directory
+class Zip64EndRecord {
+  #buffer;
+  #offset;
+  constructor(buffer, offset = 0) {
+    validateArchiveRange(buffer, offset, 56, 'Zip64 end of central directory record');
+    if (buffer.readUInt32LE(offset) !== SIG_ZIP64_EOCD_RECORD) {
+      throw new ERR_ZIP_INVALID_ARCHIVE(
+        'Zip64 end of central directory signature is invalid');
+    }
+    this.#buffer = buffer;
+    this.#offset = offset;
+  }
+  get diskNumber() { return this.#buffer.readUInt32LE(this.#offset + 16); }
+  get centralDirectoryDiskNumber() { return this.#buffer.readUInt32LE(this.#offset + 20); }
+  get centralDirectoryDiskRecords() { return readSafeUint64(this.#buffer, this.#offset + 24); }
+  get centralDirectoryTotalRecords() { return readSafeUint64(this.#buffer, this.#offset + 32); }
+  get centralDirectorySize() { return readSafeUint64(this.#buffer, this.#offset + 40); }
+  get centralDirectoryOffset() { return readSafeUint64(this.#buffer, this.#offset + 48); }
+}
+
+// Zip64 end of central directory locator (sec. 4.3.15).
+// 0    4   Signature = 0x07064b50
+// 4    4   Disk with the Zip64 end of central directory record
+// 8    8   Offset of the Zip64 end of central directory record
+// 16   4   Total number of disks
+class Zip64EndLocator {
+  #buffer;
+  #offset;
+  constructor(buffer, offset = 0) {
+    validateArchiveRange(buffer, offset, 20, 'Zip64 end of central directory locator');
+    if (buffer.readUInt32LE(offset) !== SIG_ZIP64_EOCD_LOCATOR) {
+      throw new ERR_ZIP_INVALID_ARCHIVE(
+        'Zip64 end of central directory locator signature is invalid');
+    }
+    this.#buffer = buffer;
+    this.#offset = offset;
+  }
+  get recordDiskNumber() { return this.#buffer.readUInt32LE(this.#offset + 4); }
+  get recordOffset() { return readSafeUint64(this.#buffer, this.#offset + 8); }
+  get totalDisks() { return this.#buffer.readUInt32LE(this.#offset + 16); }
+}
+
+// Central directory file header (sec. 4.3.12).
+// 0    4   Signature = 0x02014b50
+// 4    2   Version made by
+// 6    2   Version needed to extract
+// 8    2   General purpose bit flag
+// 10   2   Compression method
+// 12   2   Last modification time
+// 14   2   Last modification date
+// 16   4   CRC-32
+// 20   4   Compressed size
+// 24   4   Uncompressed size
+// 28   2   File name length (n)
+// 30   2   Extra field length (m)
+// 32   2   File comment length (k)
+// 34   2   Disk number where file starts
+// 36   2   Internal file attributes
+// 38   4   External file attributes
+// 42   4   Relative offset of local file header
+// 46   n   File name
+// 46+n m   Extra field
+// 46+n+m k File comment
+class CentralFileHeader {
+  #buffer;
+  #offset;
+  #zip64 = null;
+  constructor(buffer, offset = 0) {
+    validateArchiveRange(buffer, offset, 46, 'central directory header');
+    if (buffer.readUInt32LE(offset) !== SIG_CENTRAL_FILE_HEADER) {
+      throw new ERR_ZIP_INVALID_ARCHIVE('central directory header signature is invalid');
+    }
+    this.#buffer = buffer;
+    this.#offset = offset;
+    if (offset + this.byteLength > buffer.length) {
+      throw new ERR_ZIP_INVALID_ARCHIVE('central directory header is truncated');
+    }
+  }
+  get byteOffset() { return this.#offset; }
+  get byteLength() {
+    return 46 + this.fileNameLength + this.extraFieldLength + this.fileCommentLength;
+  }
+  get version() { return this.#buffer.readUInt16LE(this.#offset + 4); }
+  // Spec field "version needed to extract" (sec. 4.4.3); not consumed today.
+  // get versionNeeded() { return this.#buffer.readUInt16LE(this.#offset + 6); }
+  get flags() { return this.#buffer.readUInt16LE(this.#offset + 8); }
+  get compressionMethod() { return this.#buffer.readUInt16LE(this.#offset + 10); }
+  get lastModified() {
+    return decodeDosDateTime(
+      this.#buffer.readUInt16LE(this.#offset + 12),
+      this.#buffer.readUInt16LE(this.#offset + 14));
+  }
+  get crc32() { return this.#buffer.readUInt32LE(this.#offset + 16); }
+  #resolveZip64() {
+    if (this.#zip64 === null) {
+      this.#zip64 = parseZip64Extra(this.extraField, {
+        uncompressedSize: this.#buffer.readUInt32LE(this.#offset + 24) === SENTINEL32,
+        compressedSize: this.#buffer.readUInt32LE(this.#offset + 20) === SENTINEL32,
+        localFileHeaderOffset: this.#buffer.readUInt32LE(this.#offset + 42) === SENTINEL32,
+        diskNumber: this.#buffer.readUInt16LE(this.#offset + 34) === SENTINEL16,
+      });
+    }
+    return this.#zip64;
+  }
+  get compressedSize() {
+    const value = this.#buffer.readUInt32LE(this.#offset + 20);
+    return value === SENTINEL32 ? this.#resolveZip64().compressedSize : value;
+  }
+  get uncompressedSize() {
+    const value = this.#buffer.readUInt32LE(this.#offset + 24);
+    return value === SENTINEL32 ? this.#resolveZip64().uncompressedSize : value;
+  }
+  get fileNameLength() { return this.#buffer.readUInt16LE(this.#offset + 28); }
+  get extraFieldLength() { return this.#buffer.readUInt16LE(this.#offset + 30); }
+  get fileCommentLength() { return this.#buffer.readUInt16LE(this.#offset + 32); }
+  get diskNumber() {
+    const value = this.#buffer.readUInt16LE(this.#offset + 34);
+    return value === SENTINEL16 ? this.#resolveZip64().diskNumber : value;
+  }
+  get internalFileAttributes() { return this.#buffer.readUInt16LE(this.#offset + 36); }
+  get externalFileAttributes() { return this.#buffer.readUInt32LE(this.#offset + 38); }
+  get localFileHeaderOffset() {
+    const value = this.#buffer.readUInt32LE(this.#offset + 42);
+    return value === SENTINEL32 ? this.#resolveZip64().localFileHeaderOffset : value;
+  }
+  get fileNameBuffer() {
+    const start = this.#offset + 46;
+    return this.#buffer.subarray(start, start + this.fileNameLength);
+  }
+  get fileName() { return this.fileNameBuffer.toString('utf8'); }
+  get extraField() {
+    const start = this.#offset + 46 + this.fileNameLength;
+    return this.#buffer.subarray(start, start + this.extraFieldLength);
+  }
+  get fileCommentBuffer() {
+    const start = this.#offset + 46 + this.fileNameLength + this.extraFieldLength;
+    return this.#buffer.subarray(start, start + this.fileCommentLength);
+  }
+  get fileComment() { return this.fileCommentBuffer.toString('utf8'); }
+  get mode() {
+    const madeBy = this.version >>> 8;
+    if (madeBy !== MADE_BY_UNIX) return 0;
+    return (this.externalFileAttributes >>> 16) & 0x1ff;
+  }
+}
+
+// Local file header (sec. 4.3.7).
+// 0    4   Signature = 0x04034b50
+// 4    2   Version needed to extract
+// 6    2   General purpose bit flag
+// 8    2   Compression method
+// 10   2   Last modification time
+// 12   2   Last modification date
+// 14   4   CRC-32
+// 18   4   Compressed size
+// 22   4   Uncompressed size
+// 26   2   File name length (n)
+// 28   2   Extra field length (m)
+// 30   n   File name
+// 30+n m   Extra field
+class LocalFileHeader {
+  #buffer;
+  #offset;
+  constructor(buffer, offset = 0) {
+    validateArchiveRange(buffer, offset, 30, 'local file header');
+    if (buffer.readUInt32LE(offset) !== SIG_LOCAL_FILE_HEADER) {
+      throw new ERR_ZIP_INVALID_ARCHIVE('local file header signature is invalid');
+    }
+    this.#buffer = buffer;
+    this.#offset = offset;
+    if (offset + this.byteLength > buffer.length) {
+      throw new ERR_ZIP_INVALID_ARCHIVE('local file header is truncated');
+    }
+  }
+  get byteLength() { return 30 + this.fileNameLength + this.extraFieldLength; }
+  get flags() { return this.#buffer.readUInt16LE(this.#offset + 6); }
+  // Spec field (sec. 4.4.5); the central directory's method is authoritative,
+  // so the local copy is not consumed today.
+  // get compressionMethod() { return this.#buffer.readUInt16LE(this.#offset + 8); }
+  get lastModified() {
+    return decodeDosDateTime(
+      this.#buffer.readUInt16LE(this.#offset + 10),
+      this.#buffer.readUInt16LE(this.#offset + 12));
+  }
+  get fileNameLength() { return this.#buffer.readUInt16LE(this.#offset + 26); }
+  get extraFieldLength() { return this.#buffer.readUInt16LE(this.#offset + 28); }
+  get fileName() {
+    const start = this.#offset + 30;
+    return this.#buffer.toString('utf8', start, start + this.fileNameLength);
+  }
+  static length(buffer, offset) {
+    if (offset + 30 > buffer.length) return 0;
+    return 30 + buffer.readUInt16LE(offset + 26) + buffer.readUInt16LE(offset + 28);
+  }
+}
+
+/**
+ * Locates and validates the end-of-archive structures (EOCD, and the Zip64
+ * EOCD locator/record when present) in `buffer`. `base` is the absolute
+ * offset of `buffer[0]` when `buffer` is only the tail of a larger file; all
+ * returned offsets are absolute. `buffer` must extend to the end of the
+ * archive.
+ * @returns {{
+ *   prefix: number,
+ *   totalRecords: number,
+ *   centralDirectoryOffset: number,
+ *   centralDirectorySize: number,
+ *   comment: Buffer,
+ * }}
+ */
+function findArchiveEnd(buffer, base = 0) {
+  if (buffer.length < 22) {
+    throw new ERR_ZIP_INVALID_ARCHIVE('no end of central directory record found');
+  }
+  const min = MathMax(0, buffer.length - (22 + SENTINEL16));
+  let eocdPos = -1;
+  // Pass 1: the comment must reach exactly to the end of the buffer (this
+  // rejects a stray EOCD-looking signature inside an earlier comment).
+  for (let pos = buffer.length - 22; pos >= min; pos--) {
+    if (buffer.readUInt32LE(pos) !== SIG_EOCD) continue;
+    if (pos + 22 + buffer.readUInt16LE(pos + 20) !== buffer.length) continue;
+    eocdPos = pos;
+    break;
+  }
+  if (eocdPos < 0) {
+    // Pass 2: tolerate trailing padding after the EOCD (some streaming
+    // writers pad their output to a fixed block size); take the last
+    // candidate found.
+    for (let pos = buffer.length - 22; pos >= min; pos--) {
+      if (buffer.readUInt32LE(pos) !== SIG_EOCD) continue;
+      if (pos + 22 + buffer.readUInt16LE(pos + 20) > buffer.length) continue;
+      eocdPos = pos;
+      break;
+    }
+  }
+  if (eocdPos < 0) {
+    throw new ERR_ZIP_INVALID_ARCHIVE('no end of central directory record found');
+  }
+  const eocd = new CentralEndHeader(buffer, eocdPos);
+  let totalRecords = eocd.centralDirectoryTotalRecords;
+  let centralDirectorySize = eocd.centralDirectorySize;
+  let centralDirectoryOffset = eocd.centralDirectoryOffset;
+  let prefix;
+  const locatorPos = eocdPos - 20;
+  if (
+    locatorPos >= 0 &&
+    buffer.readUInt32LE(locatorPos) === SIG_ZIP64_EOCD_LOCATOR
+  ) {
+    const locator = new Zip64EndLocator(buffer, locatorPos);
+    if (locator.totalDisks > 1 || locator.recordDiskNumber !== 0) {
+      throw new ERR_ZIP_UNSUPPORTED_FEATURE('multi-disk archives are not supported');
+    }
+    let recordPos = locator.recordOffset - base;
+    if (
+      !(recordPos >= 0 &&
+        recordPos + 56 <= locatorPos &&
+        buffer.readUInt32LE(recordPos) === SIG_ZIP64_EOCD_RECORD)
+    ) {
+      // Data was prepended to the archive, shifting the record; scan
+      // backward from the locator instead of trusting its recorded offset.
+      recordPos = -1;
+      const floor = MathMax(0, locatorPos - 56 - SENTINEL16);
+      for (let pos = locatorPos - 56; pos >= floor; pos--) {
+        if (buffer.readUInt32LE(pos) !== SIG_ZIP64_EOCD_RECORD) continue;
+        const size = buffer.readBigUInt64LE(pos + 4);
+        if (size >= 44n && pos + 12 + Number(size) === locatorPos) {
+          recordPos = pos;
+          break;
+        }
+      }
+      if (recordPos < 0) {
+        throw new ERR_ZIP_INVALID_ARCHIVE('Zip64 end of central directory record not found');
+      }
+    }
+    const zip64 = new Zip64EndRecord(buffer, recordPos);
+    if (zip64.diskNumber !== 0 || zip64.centralDirectoryDiskNumber !== 0) {
+      throw new ERR_ZIP_UNSUPPORTED_FEATURE('multi-disk archives are not supported');
+    }
+    if (zip64.centralDirectoryDiskRecords !== zip64.centralDirectoryTotalRecords) {
+      throw new ERR_ZIP_UNSUPPORTED_FEATURE('multi-disk archives are not supported');
+    }
+    totalRecords = zip64.centralDirectoryTotalRecords;
+    centralDirectorySize = zip64.centralDirectorySize;
+    centralDirectoryOffset = zip64.centralDirectoryOffset;
+    prefix = base + recordPos - (centralDirectoryOffset + centralDirectorySize);
+  } else {
+    if (eocd.diskNumber !== 0 || eocd.centralDirectoryDiskNumber !== 0) {
+      throw new ERR_ZIP_UNSUPPORTED_FEATURE('multi-disk archives are not supported');
+    }
+    if (eocd.centralDirectoryDiskRecords !== totalRecords) {
+      throw new ERR_ZIP_UNSUPPORTED_FEATURE('multi-disk archives are not supported');
+    }
+    prefix = base + eocdPos - (centralDirectoryOffset + centralDirectorySize);
+  }
+  if (prefix < 0) {
+    throw new ERR_ZIP_INVALID_ARCHIVE('central directory does not fit inside the archive');
+  }
+  if (totalRecords * 46 > centralDirectorySize) {
+    throw new ERR_ZIP_INVALID_ARCHIVE(
+      'central directory record count is inconsistent with its size');
+  }
+  return {
+    prefix,
+    totalRecords,
+    centralDirectoryOffset: centralDirectoryOffset + prefix,
+    centralDirectorySize,
+    comment: eocd.commentBuffer,
+  };
+}
+
+// -- header builders (write path) --------------------------------------------
+
+function buildLocalHeader(meta) {
+  const streaming = (meta.flags & FLAG_DATA_DESCRIPTOR) !== 0;
+  const zip64 =
+    streaming ||
+    meta.compressedSize >= SENTINEL32 ||
+    meta.uncompressedSize >= SENTINEL32;
+  const extraLength = zip64 ? 20 : 0;
+  const buffer = Buffer.allocUnsafe(30 + meta.name.length + extraLength);
+  buffer.writeUInt32LE(SIG_LOCAL_FILE_HEADER, 0);
+  buffer.writeUInt16LE(zip64 ? VERSION_ZIP64 : VERSION_DEFAULT, 4);
+  buffer.writeUInt16LE(meta.flags, 6);
+  buffer.writeUInt16LE(meta.method, 8);
+  const { time, date } = encodeDosDateTime(meta.modified);
+  buffer.writeUInt16LE(time, 10);
+  buffer.writeUInt16LE(date, 12);
+  buffer.writeUInt32LE(streaming ? 0 : meta.crc, 14);
+  buffer.writeUInt32LE(zip64 ? SENTINEL32 : meta.compressedSize, 18);
+  buffer.writeUInt32LE(zip64 ? SENTINEL32 : meta.uncompressedSize, 22);
+  buffer.writeUInt16LE(meta.name.length, 26);
+  buffer.writeUInt16LE(extraLength, 28);
+  meta.name.copy(buffer, 30);
+  if (zip64) {
+    const pos = 30 + meta.name.length;
+    buffer.writeUInt16LE(ZIP64_EXTRA_ID, pos);
+    buffer.writeUInt16LE(16, pos + 2);
+    writeSafeUint64(buffer, pos + 4, streaming ? 0 : meta.uncompressedSize);
+    writeSafeUint64(buffer, pos + 12, streaming ? 0 : meta.compressedSize);
+  }
+  return buffer;
+}
+
+function buildCentralHeader(meta, localOffset) {
+  const zip64Streaming = (meta.flags & FLAG_DATA_DESCRIPTOR) !== 0;
+  const u64 = meta.uncompressedSize >= SENTINEL32;
+  const c64 = meta.compressedSize >= SENTINEL32;
+  const o64 = localOffset >= SENTINEL32;
+  const zip64Fields = (u64 ? 1 : 0) + (c64 ? 1 : 0) + (o64 ? 1 : 0);
+  const extraLength = zip64Fields ? 4 + 8 * zip64Fields : 0;
+  const zip64 = zip64Streaming || meta.compressedSize >= SENTINEL32 ||
+    meta.uncompressedSize >= SENTINEL32 || zip64Fields > 0;
+  const buffer = Buffer.allocUnsafe(
+    46 + meta.name.length + extraLength + meta.comment.length);
+  buffer.writeUInt32LE(SIG_CENTRAL_FILE_HEADER, 0);
+  buffer.writeUInt16LE(
+    (MADE_BY_UNIX << 8) | (zip64 ? VERSION_ZIP64 : VERSION_DEFAULT), 4);
+  buffer.writeUInt16LE(zip64 ? VERSION_ZIP64 : VERSION_DEFAULT, 6);
+  buffer.writeUInt16LE(meta.flags, 8);
+  buffer.writeUInt16LE(meta.method, 10);
+  const { time, date } = encodeDosDateTime(meta.modified);
+  buffer.writeUInt16LE(time, 12);
+  buffer.writeUInt16LE(date, 14);
+  buffer.writeUInt32LE(meta.crc, 16);
+  buffer.writeUInt32LE(c64 ? SENTINEL32 : meta.compressedSize, 20);
+  buffer.writeUInt32LE(u64 ? SENTINEL32 : meta.uncompressedSize, 24);
+  buffer.writeUInt16LE(meta.name.length, 28);
+  buffer.writeUInt16LE(extraLength, 30);
+  buffer.writeUInt16LE(meta.comment.length, 32);
+  buffer.writeUInt16LE(0, 34); // disk number
+  buffer.writeUInt16LE(meta.internal, 36);
+  buffer.writeUInt32LE(meta.external, 38);
+  buffer.writeUInt32LE(o64 ? SENTINEL32 : localOffset, 42);
+  meta.name.copy(buffer, 46);
+  let pos = 46 + meta.name.length;
+  if (zip64Fields) {
+    buffer.writeUInt16LE(ZIP64_EXTRA_ID, pos);
+    buffer.writeUInt16LE(8 * zip64Fields, pos + 2);
+    pos += 4;
+    if (u64) {
+      writeSafeUint64(buffer, pos, meta.uncompressedSize);
+      pos += 8;
+    }
+    if (c64) {
+      writeSafeUint64(buffer, pos, meta.compressedSize);
+      pos += 8;
+    }
+    if (o64) {
+      writeSafeUint64(buffer, pos, localOffset);
+      pos += 8;
+    }
+  }
+  meta.comment.copy(buffer, pos);
+  return buffer;
+}
+
+// Zip64 data descriptor (sec. 4.3.9): emitted after a streamed entry, whose
+// local header always carries a Zip64 extra field.
+function buildDataDescriptor64(crc, compressedSize, uncompressedSize) {
+  const buffer = Buffer.allocUnsafe(24);
+  buffer.writeUInt32LE(SIG_DATA_DESCRIPTOR, 0);
+  buffer.writeUInt32LE(crc, 4);
+  writeSafeUint64(buffer, 8, compressedSize);
+  writeSafeUint64(buffer, 16, uncompressedSize);
+  return buffer;
+}
+
+function buildEndOfCentralDirectory(count, size, offset, comment) {
+  const buffer = Buffer.allocUnsafe(22 + comment.length);
+  buffer.writeUInt32LE(SIG_EOCD, 0);
+  buffer.writeUInt16LE(0, 4); // disk number
+  buffer.writeUInt16LE(0, 6); // Central directory disk number
+  buffer.writeUInt16LE(MathMin(count, SENTINEL16), 8);
+  buffer.writeUInt16LE(MathMin(count, SENTINEL16), 10);
+  buffer.writeUInt32LE(MathMin(size, SENTINEL32), 12);
+  buffer.writeUInt32LE(MathMin(offset, SENTINEL32), 16);
+  buffer.writeUInt16LE(comment.length, 20);
+  comment.copy(buffer, 22);
+  return buffer;
+}
+
+function buildZip64EndRecord(count, size, offset) {
+  const buffer = Buffer.allocUnsafe(56);
+  buffer.writeUInt32LE(SIG_ZIP64_EOCD_RECORD, 0);
+  writeSafeUint64(buffer, 4, 44); // Size of the remainder of this record
+  buffer.writeUInt16LE((MADE_BY_UNIX << 8) | VERSION_ZIP64, 12);
+  buffer.writeUInt16LE(VERSION_ZIP64, 14);
+  buffer.writeUInt32LE(0, 16); // disk number
+  buffer.writeUInt32LE(0, 20); // Central directory disk number
+  writeSafeUint64(buffer, 24, count);
+  writeSafeUint64(buffer, 32, count);
+  writeSafeUint64(buffer, 40, size);
+  writeSafeUint64(buffer, 48, offset);
+  return buffer;
+}
+
+function buildZip64EndLocator(recordOffset) {
+  const buffer = Buffer.allocUnsafe(20);
+  buffer.writeUInt32LE(SIG_ZIP64_EOCD_LOCATOR, 0);
+  buffer.writeUInt32LE(0, 4); // Disk with the Zip64 EOCD record
+  writeSafeUint64(buffer, 8, recordOffset);
+  buffer.writeUInt32LE(1, 16); // total disks
+  return buffer;
+}
+
+// -- buffer coercion ----------------------------------------------------------
+
+function toBuffer(value, name) {
+  if (isUint8Array(value)) {
+    return Buffer.isBuffer(value) ?
+      value : Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+  }
+  if (isArrayBufferView(value)) {
+    return Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+  }
+  if (isAnyArrayBuffer(value)) {
+    return Buffer.from(value);
+  }
+  throw new ERR_INVALID_ARG_TYPE(
+    name, ['Buffer', 'TypedArray', 'DataView', 'ArrayBuffer'], value);
+}
+
+// -- compression plumbing ------------------------------------------------------
+
+function deflateRawAsync(buffer) {
+  return new Promise((resolve, reject) => {
+    lazyZlib().deflateRaw(buffer, (err, result) => {
+      if (err) reject(err);
+      else resolve(result);
+    });
+  });
+}
+
+function inflateRawAsync(buffer, options) {
+  return new Promise((resolve, reject) => {
+    lazyZlib().inflateRaw(buffer, options, (err, result) => {
+      if (err) reject(err);
+      else resolve(result);
+    });
+  });
+}
+
+async function* pumpThroughTransform(source, transform) {
+  const input = Readable.from(source);
+  input.on('error', (err) => transform.destroy(err));
+  input.pipe(transform);
+  try {
+    yield* transform;
+  } finally {
+    if (!input.destroyed) input.destroy();
+    if (!transform.destroyed) transform.destroy();
+  }
+}
+
+function deflateRawStream(source) {
+  return pumpThroughTransform(source, lazyZlib().createDeflateRaw());
+}
+
+function inflateRawStream(source) {
+  return pumpThroughTransform(source, lazyZlib().createInflateRaw());
+}
+
+function zstdCompressAsync(buffer) {
+  return new Promise((resolve, reject) => {
+    lazyZlib().zstdCompress(buffer, (err, result) => {
+      if (err) reject(err);
+      else resolve(result);
+    });
+  });
+}
+
+function zstdDecompressAsync(buffer, options) {
+  return new Promise((resolve, reject) => {
+    lazyZlib().zstdDecompress(buffer, options, (err, result) => {
+      if (err) reject(err);
+      else resolve(result);
+    });
+  });
+}
+
+function zstdCompressStream(source) {
+  return pumpThroughTransform(source, lazyZlib().createZstdCompress());
+}
+
+function zstdDecompressStream(source) {
+  return pumpThroughTransform(source, lazyZlib().createZstdDecompress());
+}
+
+/**
+ * @typedef {{
+ *   name: string,
+ *   flags: number,
+ *   method: number,
+ *   crc32: number,
+ *   uncompressedSize: number,
+ * }} ZipMemberInfo
+ */
+
+/**
+ * Decodes one member's compressed byte stream: rejects encrypted entries and
+ * unsupported compression methods, inflates method 8 or decompresses method
+ * 93 (Zstandard), enforces the declared uncompressed size and verifies
+ * CRC-32 (on by default).
+ * @param {AsyncIterable<Buffer>} source
+ * @param {ZipMemberInfo} info
+ * @param {{ verify?: boolean, maxSize?: number }} [options]
+ * @yields {Buffer}
+ */
+async function* decodeMemberStream(source, info, options) {
+  if (info.flags & FLAG_ENCRYPTED) {
+    throw new ERR_ZIP_UNSUPPORTED_FEATURE(
+      `entry ${JSONStringify(info.name)} is encrypted`);
+  }
+  if (info.method !== METHOD_STORE && info.method !== METHOD_DEFLATE && info.method !== METHOD_ZSTD) {
+    throw new ERR_ZIP_UNSUPPORTED_FEATURE(
+      `entry ${JSONStringify(info.name)} uses compression method ${info.method}`);
+  }
+  const verify = options?.verify !== false;
+  if (options?.maxSize !== undefined && info.uncompressedSize > options.maxSize) {
+    throw new ERR_ZIP_ENTRY_TOO_LARGE(
+      `entry ${JSONStringify(info.name)} declares ${info.uncompressedSize} bytes, ` +
+      `exceeding the ${options.maxSize} byte limit`);
+  }
+  let produced = 0;
+  let state = 0;
+  const decoded = info.method === METHOD_DEFLATE ? inflateRawStream(source) :
+    info.method === METHOD_ZSTD ? zstdDecompressStream(source) : source;
+  for await (const chunk of decoded) {
+    produced += chunk.length;
+    if (produced > info.uncompressedSize) {
+      throw new ERR_ZIP_ENTRY_CORRUPT(
+        `entry ${JSONStringify(info.name)} inflates beyond its declared size of ` +
+        `${info.uncompressedSize} bytes`);
+    }
+    if (verify) state = crc32Native(chunk, state);
+    yield chunk;
+  }
+  if (produced !== info.uncompressedSize) {
+    throw new ERR_ZIP_ENTRY_CORRUPT(
+      `entry ${JSONStringify(info.name)} is truncated: got ${produced} of ` +
+      `${info.uncompressedSize} bytes`);
+  }
+  if (verify && state !== info.crc32) {
+    throw new ERR_ZIP_ENTRY_CORRUPT(
+      `entry ${JSONStringify(info.name)} failed CRC-32 verification`);
+  }
+}
+
+/**
+ * The synchronous counterpart of `decodeMemberStream()`. There is no public
+ * synchronous incremental inflate API, so - unlike the streaming path -
+ * `compressed` must already be the member's complete compressed byte
+ * stream, and the whole result is produced (and verified) in one call
+ * rather than yielded incrementally.
+ * @param {Buffer} compressed
+ * @param {ZipMemberInfo} info
+ * @param {{ verify?: boolean, maxSize?: number }} [options]
+ * @returns {Buffer}
+ */
+function decodeMemberSync(compressed, info, options) {
+  if (info.flags & FLAG_ENCRYPTED) {
+    throw new ERR_ZIP_UNSUPPORTED_FEATURE(
+      `entry ${JSONStringify(info.name)} is encrypted`);
+  }
+  if (info.method !== METHOD_STORE && info.method !== METHOD_DEFLATE && info.method !== METHOD_ZSTD) {
+    throw new ERR_ZIP_UNSUPPORTED_FEATURE(
+      `entry ${JSONStringify(info.name)} uses compression method ${info.method}`);
+  }
+  const verify = options?.verify !== false;
+  if (options?.maxSize !== undefined && info.uncompressedSize > options.maxSize) {
+    throw new ERR_ZIP_ENTRY_TOO_LARGE(
+      `entry ${JSONStringify(info.name)} declares ${info.uncompressedSize} bytes, ` +
+      `exceeding the ${options.maxSize} byte limit`);
+  }
+  let data;
+  if (info.method === METHOD_DEFLATE) {
+    try {
+      data = lazyZlib().inflateRawSync(
+        compressed, options?.maxSize !== undefined ? { maxOutputLength: options.maxSize } : undefined);
+    } catch (err) {
+      if (err?.code === 'ERR_BUFFER_TOO_LARGE') {
+        throw new ERR_ZIP_ENTRY_TOO_LARGE(
+          `entry ${JSONStringify(info.name)} inflates beyond the ${options.maxSize} byte limit`);
+      }
+      throw new ERR_ZIP_ENTRY_CORRUPT(
+        `entry ${JSONStringify(info.name)} failed to inflate: ${err.message}`);
+    }
+  } else if (info.method === METHOD_ZSTD) {
+    try {
+      data = lazyZlib().zstdDecompressSync(
+        compressed, options?.maxSize !== undefined ? { maxOutputLength: options.maxSize } : undefined);
+    } catch (err) {
+      if (err?.code === 'ERR_BUFFER_TOO_LARGE') {
+        throw new ERR_ZIP_ENTRY_TOO_LARGE(
+          `entry ${JSONStringify(info.name)} decompresses beyond the ${options.maxSize} byte limit`);
+      }
+      throw new ERR_ZIP_ENTRY_CORRUPT(
+        `entry ${JSONStringify(info.name)} failed to decompress: ${err.message}`);
+    }
+  } else {
+    data = compressed;
+  }
+  if (data.length !== info.uncompressedSize) {
+    throw new ERR_ZIP_ENTRY_CORRUPT(
+      `entry ${JSONStringify(info.name)} produced ${data.length} bytes, expected ` +
+      `${info.uncompressedSize}`);
+  }
+  if (verify) {
+    const crc = crc32Native(data, 0);
+    if (crc !== info.crc32) {
+      throw new ERR_ZIP_ENTRY_CORRUPT(
+        `entry ${JSONStringify(info.name)} failed CRC-32 verification`);
+    }
+  }
+  return data;
+}
+
+function createEntryMeta(filename, options) {
+  validateString(filename, 'filename');
+  const name = Buffer.from(filename, 'utf8');
+  if (name.length === 0) {
+    throw new ERR_INVALID_ARG_VALUE('filename', filename, 'must not be empty');
+  }
+  if (name.length > SENTINEL16) {
+    throw new ERR_ZIP_ENTRY_TOO_LARGE(
+      'the entry name must not exceed 65535 bytes when encoded as UTF-8');
+  }
+  let comment = EMPTY_BUFFER;
+  if (options?.comment !== undefined) {
+    validateString(options.comment, 'options.comment');
+    comment = Buffer.from(options.comment, 'utf8');
+    if (comment.length > SENTINEL16) {
+      throw new ERR_ZIP_ENTRY_TOO_LARGE(
+        'the entry comment must not exceed 65535 bytes when encoded as UTF-8');
+    }
+  }
+  const isDirectory = StringPrototypeEndsWith(filename, '/');
+  const mode = options?.mode ?? (isDirectory ? 0o755 : 0o644);
+  validateUint32(mode, 'options.mode');
+  const modified = options?.modified ?? new Date();
+  if (!isDate(modified)) {
+    throw new ERR_INVALID_ARG_TYPE('options.modified', 'Date', modified);
+  }
+  if (options?.method !== undefined &&
+      options.method !== 'deflate' && options.method !== 'store' && options.method !== 'zstd') {
+    throw new ERR_INVALID_ARG_VALUE(
+      'options.method', options.method, "must be 'deflate', 'store', or 'zstd'");
+  }
+  const typeBits = isDirectory ? S_IFDIR : S_IFREG;
+  const unixAttrs = (typeBits | (mode & 0o7777)) & SENTINEL16;
+  const external = ((unixAttrs << 16) | (isDirectory ? 0x10 : 0)) >>> 0;
+  return {
+    name,
+    comment,
+    flags: FLAG_UTF8,
+    method: 0,
+    crc: 0,
+    compressedSize: 0,
+    uncompressedSize: 0,
+    modified,
+    external,
+    internal: 0,
+    pending: true,
+  };
+}
+
+/**
+ * A single file or directory inside a ZIP archive: reading, writing, and
+ * (de)serializing one archive member.
+ */
+class ZipEntry {
+  #central;
+  #local;
+  #content;
+  #source = null;
+  #meta = null;
+  #serialized = false;
+  // When #fd is non-null the entry is "file-backed": it holds no content
+  // buffer, only a descriptor and the local-header offset, and reads its
+  // compressed bytes from disk on demand (see #compressedBytes/#rawChunks).
+  // #contentOffset caches the resolved start of the compressed data (a
+  // number, not a buffer) once the local header has been read.
+  #fd = null;
+  #localOffset = -1;
+  #contentOffset = -1;
+
+  /**
+   * @private
+   */
+  constructor(central, local, content, fd = null, localOffset = -1) {
+    this.#central = central;
+    this.#local = local;
+    this.#content = content;
+    this.#fd = fd;
+    this.#localOffset = localOffset;
+  }
+
+  get compressed() { return this.method === 8; }
+  get rawContent() { return this.#content; }
+  get method() {
+    return this.#meta ? this.#meta.method : this.#central.compressionMethod;
+  }
+  get flags() {
+    return this.#meta ? this.#meta.flags : (this.#local ?? this.#central).flags;
+  }
+  get crc32() {
+    if (this.#meta) {
+      this.#assertNotPending();
+      return this.#meta.crc;
+    }
+    return this.#central.crc32;
+  }
+  get name() {
+    return this.#meta ? this.#meta.name.toString('utf8') : (this.#local ?? this.#central).fileName;
+  }
+  get comment() {
+    return this.#meta ? this.#meta.comment.toString('utf8') : this.#central.fileComment;
+  }
+  get size() {
+    if (this.#meta) {
+      this.#assertNotPending();
+      return this.#meta.uncompressedSize;
+    }
+    return this.#central.uncompressedSize;
+  }
+  get compressedSize() {
+    if (this.#meta) {
+      this.#assertNotPending();
+      return this.#meta.compressedSize;
+    }
+    return this.#central.compressedSize;
+  }
+  get modified() {
+    return this.#meta ? this.#meta.modified : (this.#local ?? this.#central).lastModified;
+  }
+  get mode() {
+    if (this.#meta) return (this.#meta.external >>> 16) & 0x1ff;
+    return this.#central.mode;
+  }
+  get isFile() { return !this.isDirectory; }
+  get isDirectory() { return StringPrototypeEndsWith(this.name, '/'); }
+
+  #assertNotPending() {
+    if (this.#meta?.pending) {
+      throw new ERR_INVALID_STATE(
+        'this streaming entry has not finished serializing yet');
+    }
+  }
+
+  #finalizeMeta() {
+    if (this.#meta) {
+      this.#assertNotPending();
+      return this.#meta;
+    }
+    const central = this.#central;
+    // Descriptor entries (bit 3) are re-emitted with known sizes/CRC and bit
+    // 3 cleared: re-serialization never reproduces a bit-3 local header
+    // without a data descriptor. Sizes come from the central directory
+    // (Zip64-aware); foreign extra fields are dropped and Zip64 extras are
+    // regenerated as needed.
+    const meta = {
+      name: central.fileNameBuffer,
+      comment: central.fileCommentBuffer,
+      flags: central.flags & ~FLAG_DATA_DESCRIPTOR,
+      method: central.compressionMethod,
+      crc: central.crc32,
+      compressedSize: central.compressedSize,
+      uncompressedSize: central.uncompressedSize,
+      modified: central.lastModified,
+      external: central.externalFileAttributes,
+      internal: central.internalFileAttributes,
+      pending: false,
+    };
+    this.#meta = meta;
+    return meta;
+  }
+
+  // Resolve (and cache) the file offset where this file-backed entry's
+  // compressed data begins, by reading the local file header - whose length
+  // (fixed 30 bytes plus variable name/extra fields) is only known from the
+  // file itself, not from the central directory.
+  async #resolveContentOffset() {
+    if (this.#contentOffset >= 0) return this.#contentOffset;
+    const fixed = Buffer.allocUnsafe(30);
+    await readFdFully(this.#fd, fixed, this.#localOffset);
+    if (fixed.readUInt32LE(0) !== SIG_LOCAL_FILE_HEADER) {
+      throw new ERR_ZIP_INVALID_ARCHIVE(
+        `entry ${JSONStringify(this.name)} has an invalid local file header`);
+    }
+    this.#contentOffset = this.#localOffset + LocalFileHeader.length(fixed, 0);
+    return this.#contentOffset;
+  }
+  #resolveContentOffsetSync() {
+    if (this.#contentOffset >= 0) return this.#contentOffset;
+    const fixed = Buffer.allocUnsafe(30);
+    readFdFullySync(this.#fd, fixed, this.#localOffset);
+    if (fixed.readUInt32LE(0) !== SIG_LOCAL_FILE_HEADER) {
+      throw new ERR_ZIP_INVALID_ARCHIVE(
+        `entry ${JSONStringify(this.name)} has an invalid local file header`);
+    }
+    this.#contentOffset = this.#localOffset + LocalFileHeader.length(fixed, 0);
+    return this.#contentOffset;
+  }
+  // The in-memory raw bytes, or a clean state error when there are none - a
+  // write-streaming entry (`createStream()`) has no readable content until it
+  // has been serialized into a backing archive (after which `addEntry()`
+  // promotes it to file-backed; see [kPromote]).
+  #inMemoryCompressed() {
+    if (this.#content === null) {
+      throw new ERR_INVALID_STATE(
+        'the content of a streaming entry is not available for reading');
+    }
+    return this.#content;
+  }
+  // The entry's raw (still-compressed) bytes. For an in-memory entry this is
+  // the buffer it was built with; for a file-backed entry it is read from
+  // disk on demand and never retained. Callers own the returned buffer.
+  async #compressedBytes() {
+    if (this.#fd === null) return this.#inMemoryCompressed();
+    const size = this.compressedSize;
+    // A member at or beyond the maximum Buffer length cannot be materialized
+    // in one allocation; stream it instead. (kMaxLength equals the safe
+    // integer ceiling on 64-bit, so a larger size fails to parse anyway.)
+    if (size >= kMaxLength) {
+      throw new ERR_ZIP_ENTRY_TOO_LARGE(
+        `entry ${JSONStringify(this.name)} is too large to buffer ` +
+        `(${size} compressed bytes); use contentIterator() instead`);
+    }
+    const start = await this.#resolveContentOffset();
+    const compressed = Buffer.allocUnsafe(size);
+    await readFdFully(this.#fd, compressed, start);
+    return compressed;
+  }
+  #compressedBytesSync() {
+    if (this.#fd === null) return this.#inMemoryCompressed();
+    const size = this.compressedSize;
+    if (size >= kMaxLength) {
+      throw new ERR_ZIP_ENTRY_TOO_LARGE(
+        `entry ${JSONStringify(this.name)} is too large to buffer ` +
+        `(${size} compressed bytes); use contentIterator() instead`);
+    }
+    const start = this.#resolveContentOffsetSync();
+    const compressed = Buffer.allocUnsafe(size);
+    readFdFullySync(this.#fd, compressed, start);
+    return compressed;
+  }
+  // The entry's raw compressed bytes as a bounded-memory chunk stream, read
+  // straight from disk (file-backed entries only). Nothing is retained.
+  async *#rawChunks() {
+    const fd = this.#fd;
+    let pos = await this.#resolveContentOffset();
+    let remaining = this.compressedSize;
+    while (remaining > 0) {
+      const take = MathMin(READ_CHUNK_SIZE, remaining);
+      const chunk = Buffer.allocUnsafe(take);
+      await readFdFully(fd, chunk, pos);
+      pos += take;
+      remaining -= take;
+      yield chunk;
+    }
+  }
+  *#rawChunksSync() {
+    const fd = this.#fd;
+    let pos = this.#resolveContentOffsetSync();
+    let remaining = this.compressedSize;
+    while (remaining > 0) {
+      const take = MathMin(READ_CHUNK_SIZE, remaining);
+      const chunk = Buffer.allocUnsafe(take);
+      readFdFullySync(fd, chunk, pos);
+      pos += take;
+      remaining -= take;
+      yield chunk;
+    }
+  }
+
+  /**
+   * @param {{ verify?: boolean, maxSize?: number }} [options]
+   * @returns {Promise<Buffer>}
+   */
+  async content(options) {
+    if (this.flags & FLAG_ENCRYPTED) {
+      throw new ERR_ZIP_UNSUPPORTED_FEATURE(
+        `entry ${JSONStringify(this.name)} is encrypted`);
+    }
+    if (this.method !== METHOD_STORE && this.method !== METHOD_DEFLATE && this.method !== METHOD_ZSTD) {
+      throw new ERR_ZIP_UNSUPPORTED_FEATURE(
+        `entry ${JSONStringify(this.name)} uses compression method ${this.method}`);
+    }
+    const declared = this.size;
+    const maxSize = options?.maxSize ?? maxZipContentSize;
+    if (declared > maxSize) {
+      throw new ERR_ZIP_ENTRY_TOO_LARGE(
+        `entry ${JSONStringify(this.name)} declares ${declared} bytes, ` +
+        `exceeding the ${maxSize} byte limit`);
+    }
+    const verify = options?.verify !== false;
+    const compressed = await this.#compressedBytes();
+    let data;
+    if (this.method === METHOD_DEFLATE) {
+      try {
+        data = await inflateRawAsync(compressed, { maxOutputLength: maxSize });
+      } catch (err) {
+        if (err?.code === 'ERR_BUFFER_TOO_LARGE') {
+          throw new ERR_ZIP_ENTRY_TOO_LARGE(
+            `entry ${JSONStringify(this.name)} inflates beyond the ${maxSize} byte limit`);
+        }
+        throw new ERR_ZIP_ENTRY_CORRUPT(
+          `entry ${JSONStringify(this.name)} failed to inflate: ${err.message}`);
+      }
+    } else if (this.method === METHOD_ZSTD) {
+      try {
+        data = await zstdDecompressAsync(compressed, { maxOutputLength: maxSize });
+      } catch (err) {
+        if (err?.code === 'ERR_BUFFER_TOO_LARGE') {
+          throw new ERR_ZIP_ENTRY_TOO_LARGE(
+            `entry ${JSONStringify(this.name)} decompresses beyond the ${maxSize} byte limit`);
+        }
+        throw new ERR_ZIP_ENTRY_CORRUPT(
+          `entry ${JSONStringify(this.name)} failed to decompress: ${err.message}`);
+      }
+    } else {
+      data = compressed;
+    }
+    if (data.length !== declared) {
+      throw new ERR_ZIP_ENTRY_CORRUPT(
+        `entry ${JSONStringify(this.name)} produced ${data.length} bytes, expected ${declared}`);
+    }
+    if (verify) {
+      const crc = crc32Native(data, 0);
+      if (crc !== this.crc32) {
+        throw new ERR_ZIP_ENTRY_CORRUPT(
+          `entry ${JSONStringify(this.name)} failed CRC-32 verification`);
+      }
+    }
+    return data;
+  }
+
+  /**
+   * The synchronous counterpart of `content()`. Blocks the event loop and
+   * further JavaScript execution until the whole entry has been read and, if
+   * applicable, inflated - use only where synchronous I/O is appropriate
+   * (for example, short-lived scripts or startup code), not in code that
+   * must stay responsive.
+   * @param {{ verify?: boolean, maxSize?: number }} [options]
+   * @returns {Buffer}
+   */
+  contentSync(options) {
+    const declared = this.size;
+    const maxSize = options?.maxSize ?? maxZipContentSize;
+    if (declared > maxSize) {
+      throw new ERR_ZIP_ENTRY_TOO_LARGE(
+        `entry ${JSONStringify(this.name)} declares ${declared} bytes, ` +
+        `exceeding the ${maxSize} byte limit`);
+    }
+    const compressed = this.#compressedBytesSync();
+    return decodeMemberSync(compressed, {
+      name: this.name,
+      flags: this.flags,
+      method: this.method,
+      crc32: this.crc32,
+      uncompressedSize: declared,
+    }, { verify: options?.verify, maxSize });
+  }
+
+  // The raw (still-compressed) bytes as an async iterable, without buffering
+  // the whole member: straight from disk for a file-backed entry, or the
+  // single in-memory buffer otherwise. Throws synchronously for a pending
+  // write-streaming entry, whose content is not yet available for reading.
+  #rawSource() {
+    if (this.#fd !== null) return this.#rawChunks();
+    const content = this.#inMemoryCompressed();
+    return (async function* () {
+      if (content.length) yield content;
+    })();
+  }
+
+  /**
+   * Yields the entry's decompressed content as a bounded-memory async
+   * iterator of `Buffer` chunks, decompressing on the way and (by default)
+   * verifying CRC-32. For a file-backed entry (from `ZipFile.get()`) the
+   * compressed bytes are read from disk as they are consumed and nothing is
+   * retained.
+   * @param {{ verify?: boolean, maxSize?: number }} [options]
+   * @returns {AsyncGenerator<Buffer>}
+   */
+  contentIterator(options) {
+    return decodeMemberStream(this.#rawSource(), {
+      name: this.name,
+      flags: this.flags,
+      method: this.method,
+      crc32: this.crc32,
+      uncompressedSize: this.size,
+    }, options);
+  }
+
+  *[SymbolIterator]() {
+    if (this.#source) {
+      throw new ERR_INVALID_STATE('a streaming entry cannot be serialized synchronously');
+    }
+    const meta = this.#finalizeMeta();
+    yield buildLocalHeader(meta);
+    if (this.#fd !== null) {
+      yield* this.#rawChunksSync();
+    } else if (this.#content?.length) {
+      yield this.#content;
+    }
+  }
+
+  async *[SymbolAsyncIterator]() {
+    const source = this.#source;
+    if (!source) {
+      if (this.#fd !== null) {
+        yield buildLocalHeader(this.#finalizeMeta());
+        yield* this.#rawChunks();
+        return;
+      }
+      yield* this[SymbolIterator]();
+      return;
+    }
+    if (this.#serialized) {
+      throw new ERR_INVALID_STATE('a streaming entry can only be serialized once');
+    }
+    this.#serialized = true;
+    const meta = this.#meta;
+    yield buildLocalHeader(meta);
+    let state = 0;
+    let uncompressedSize = 0;
+    let compressedSize = 0;
+    const counted = (async function* () {
+      for await (const chunk of source) {
+        if (!isUint8Array(chunk)) {
+          throw new ERR_INVALID_ARG_TYPE('chunk', 'Uint8Array', chunk);
+        }
+        if (!chunk.length) continue;
+        state = crc32Native(chunk, state);
+        uncompressedSize += chunk.length;
+        yield chunk;
+      }
+    })();
+    const output = meta.method === METHOD_DEFLATE ? deflateRawStream(counted) :
+      meta.method === METHOD_ZSTD ? zstdCompressStream(counted) : counted;
+    for await (const chunk of output) {
+      compressedSize += chunk.length;
+      yield chunk;
+    }
+    meta.crc = state;
+    meta.uncompressedSize = uncompressedSize;
+    meta.compressedSize = compressedSize;
+    meta.pending = false;
+    yield buildDataDescriptor64(meta.crc, compressedSize, uncompressedSize);
+  }
+
+  /**
+   * @private
+   * @param {number} localOffset
+   * @returns {Buffer}
+   */
+  [kFinalize](localOffset) {
+    validateInteger(localOffset, 'localOffset', 0, NumberMAX_SAFE_INTEGER);
+    return buildCentralHeader(this.#finalizeMeta(), localOffset);
+  }
+
+  // Rebind a just-serialized write-streaming entry to its on-disk copy so it
+  // stops being dead weight: after `addEntry()`/`addEntrySync()` writes the
+  // entry into `fd` at `localOffset` (its local-header start), the spent
+  // source is dropped and the entry becomes a readable, re-serializable
+  // file-backed entry (valid while `fd` stays open). Only a spent stream
+  // entry - one with neither an in-memory buffer nor an existing backing fd -
+  // is promoted; in-memory and already-file-backed entries are left as they
+  // are. The kept `#meta` still supplies the (now-final) name/sizes/crc.
+  [kPromote](fd, localOffset) {
+    if (this.#content !== null || this.#fd !== null) return;
+    this.#fd = fd;
+    this.#localOffset = localOffset;
+    this.#contentOffset = -1;
+    this.#source = null;
+    this.#serialized = false;
+  }
+
+  /**
+   * @param {Buffer | TypedArray | DataView | ArrayBuffer} buffer
+   * @yields {ZipEntry}
+   */
+  static *read(buffer) {
+    const buf = toBuffer(buffer, 'buffer');
+    const end = findArchiveEnd(buf);
+    let pos = end.centralDirectoryOffset;
+    const cdEnd = end.centralDirectoryOffset + end.centralDirectorySize;
+    for (let index = 0; index < end.totalRecords; index++) {
+      const central = new CentralFileHeader(buf, pos);
+      if (pos + central.byteLength > cdEnd) {
+        throw new ERR_ZIP_INVALID_ARCHIVE('central directory header is out of bounds');
+      }
+      if (central.diskNumber !== 0) {
+        throw new ERR_ZIP_UNSUPPORTED_FEATURE('multi-disk archives are not supported');
+      }
+      const localOffset = central.localFileHeaderOffset + end.prefix;
+      const local = new LocalFileHeader(buf, localOffset);
+      const dataStart = localOffset + local.byteLength;
+      const length = central.compressedSize;
+      validateArchiveRange(buf, dataStart, length, 'entry data');
+      const content = length ? buf.subarray(dataStart, dataStart + length) : EMPTY_BUFFER;
+      yield new ZipEntry(central, local, content);
+      pos = central.byteOffset + central.byteLength;
+    }
+  }
+
+  /**
+   * @param {string} filename
+   * @param {Buffer | TypedArray | DataView | ArrayBuffer} data
+   * @param {{
+   *   comment?: string,
+   *   mode?: number,
+   *   modified?: Date,
+   *   method?: 'deflate' | 'store' | 'zstd',
+   * }} [options]
+   * @returns {Promise<ZipEntry>}
+   */
+  static async create(filename, data, options) {
+    const meta = createEntryMeta(filename, options);
+    const content = toBuffer(data, 'data');
+    const isDirectory = StringPrototypeEndsWith(filename, '/');
+    if (isDirectory && content.length) {
+      throw new ERR_INVALID_ARG_VALUE('data', data, 'must be empty for a directory entry');
+    }
+    meta.crc = crc32Native(content, 0);
+    meta.uncompressedSize = content.length;
+    let finalContent = content;
+    let method = isDirectory || content.length === 0 || options?.method === 'store' ? METHOD_STORE :
+      options?.method === 'zstd' ? METHOD_ZSTD : METHOD_DEFLATE;
+    if (method === METHOD_DEFLATE) {
+      const compressed = await deflateRawAsync(content);
+      if (compressed.length >= content.length) {
+        method = METHOD_STORE; // Deflate did not help; fall back to storing
+      } else {
+        finalContent = compressed;
+      }
+    } else if (method === METHOD_ZSTD) {
+      const compressed = await zstdCompressAsync(content);
+      if (compressed.length >= content.length) {
+        method = METHOD_STORE; // Zstd did not help; fall back to storing
+      } else {
+        finalContent = compressed;
+      }
+    }
+    meta.method = method;
+    meta.compressedSize = finalContent.length;
+    meta.pending = false;
+    const entry = new ZipEntry(null, null, finalContent);
+    entry.#meta = meta;
+    return entry;
+  }
+
+  /**
+   * The synchronous counterpart of `create()`. Blocks the event loop and
+   * further JavaScript execution until done (including the deflate pass);
+   * see `contentSync()`.
+   * @param {string} filename
+   * @param {Buffer | TypedArray | DataView | ArrayBuffer} data
+   * @param {{
+   *   comment?: string,
+   *   mode?: number,
+   *   modified?: Date,
+   *   method?: 'deflate' | 'store' | 'zstd',
+   * }} [options]
+   * @returns {ZipEntry}
+   */
+  static createSync(filename, data, options) {
+    const meta = createEntryMeta(filename, options);
+    const content = toBuffer(data, 'data');
+    const isDirectory = StringPrototypeEndsWith(filename, '/');
+    if (isDirectory && content.length) {
+      throw new ERR_INVALID_ARG_VALUE('data', data, 'must be empty for a directory entry');
+    }
+    meta.crc = crc32Native(content, 0);
+    meta.uncompressedSize = content.length;
+    let finalContent = content;
+    let method = isDirectory || content.length === 0 || options?.method === 'store' ? METHOD_STORE :
+      options?.method === 'zstd' ? METHOD_ZSTD : METHOD_DEFLATE;
+    if (method === METHOD_DEFLATE) {
+      const compressed = lazyZlib().deflateRawSync(content);
+      if (compressed.length >= content.length) {
+        method = METHOD_STORE; // Deflate did not help; fall back to storing
+      } else {
+        finalContent = compressed;
+      }
+    } else if (method === METHOD_ZSTD) {
+      const compressed = lazyZlib().zstdCompressSync(content);
+      if (compressed.length >= content.length) {
+        method = METHOD_STORE; // Zstd did not help; fall back to storing
+      } else {
+        finalContent = compressed;
+      }
+    }
+    meta.method = method;
+    meta.compressedSize = finalContent.length;
+    meta.pending = false;
+    const entry = new ZipEntry(null, null, finalContent);
+    entry.#meta = meta;
+    return entry;
+  }
+
+  /**
+   * @param {string} filename
+   * @param {AsyncIterable<Buffer>} source
+   * @param {{ comment?: string, mode?: number, modified?: Date, method?: 'deflate' | 'store' | 'zstd' }} [options]
+   * @returns {ZipEntry}
+   */
+  static createStream(filename, source, options) {
+    const meta = createEntryMeta(filename, options);
+    if (StringPrototypeEndsWith(filename, '/')) {
+      throw new ERR_INVALID_ARG_VALUE('filename', filename, 'a directory entry cannot be streamed');
+    }
+    meta.flags |= FLAG_DATA_DESCRIPTOR;
+    meta.method = options?.method === 'store' ? METHOD_STORE :
+      options?.method === 'zstd' ? METHOD_ZSTD : METHOD_DEFLATE;
+    meta.pending = true;
+    const entry = new ZipEntry(null, null, null);
+    entry.#meta = meta;
+    entry.#source = source;
+    return entry;
+  }
+}
+
+/**
+ * `createZipArchive()`/`createZipArchiveSync()` (and the `ZipBuffer`
+ * `toBuffer()`/`toBufferSync()` methods that forward to them) take a single
+ * optional `options` argument that doubles as a plain archive comment: a
+ * string is shorthand for `{ comment: options }`.
+ * @param {string | { comment?: string, baseOffset?: number }} [options]
+ * @returns {{ comment: string | undefined, baseOffset: number }}
+ */
+function normalizeArchiveOptions(options) {
+  if (options === undefined) return { comment: undefined, baseOffset: 0 };
+  if (typeof options === 'string') return { comment: options, baseOffset: 0 };
+  validateObject(options, 'options');
+  const { comment, baseOffset = 0 } = options;
+  if (comment !== undefined) validateString(comment, 'options.comment');
+  validateInteger(baseOffset, 'options.baseOffset', 0, NumberMAX_SAFE_INTEGER);
+  return { comment, baseOffset };
+}
+
+/**
+ * Serializes `entries` (a (async) iterable of `ZipEntry`) into a `Readable`
+ * stream of archive byte chunks, automatically switching to Zip64 structures
+ * once the entry count or any offset/size exceeds the classic 32-/16-bit
+ * limits.
+ *
+ * `options.baseOffset` shifts every local/central header offset the archive
+ * records by that many bytes, so the emitted bytes are self-describing even
+ * when something else is written before them - for example, appending the
+ * archive after `baseOffset` bytes already written to the same file, rather
+ * than at its start.
+ * @param {Iterable<ZipEntry> | AsyncIterable<ZipEntry>} entries
+ * @param {string | { comment?: string, baseOffset?: number }} [options]
+ * @returns {Readable}
+ */
+function createZipArchive(entries, options) {
+  return Readable.from(generateZipArchive(entries, options), { objectMode: false });
+}
+
+async function* generateZipArchive(entries, options) {
+  const { comment, baseOffset } = normalizeArchiveOptions(options);
+  let commentBuffer = EMPTY_BUFFER;
+  if (comment !== undefined) {
+    commentBuffer = Buffer.from(comment, 'utf8');
+    if (commentBuffer.length > SENTINEL16) {
+      throw new ERR_ZIP_ENTRY_TOO_LARGE(
+        'the archive comment must not exceed 65535 bytes when encoded as UTF-8');
+    }
+  }
+  const centralHeaders = [];
+  let pos = baseOffset;
+  for await (const entry of entries) {
+    const start = pos;
+    for await (const chunk of entry) {
+      yield chunk;
+      pos += chunk.length;
+    }
+    ArrayPrototypePush(centralHeaders, entry[kFinalize](start));
+  }
+  const centralDirectoryOffset = pos;
+  for (let i = 0; i < centralHeaders.length; i++) {
+    const chunk = centralHeaders[i];
+    yield chunk;
+    pos += chunk.length;
+  }
+  const centralDirectorySize = pos - centralDirectoryOffset;
+  const count = centralHeaders.length;
+  const zip64 =
+    count >= SENTINEL16 ||
+    centralDirectoryOffset >= SENTINEL32 ||
+    centralDirectorySize >= SENTINEL32;
+  if (zip64) {
+    const recordOffset = pos;
+    yield buildZip64EndRecord(count, centralDirectorySize, centralDirectoryOffset);
+    yield buildZip64EndLocator(recordOffset);
+  }
+  yield buildEndOfCentralDirectory(
+    count, centralDirectorySize, centralDirectoryOffset, commentBuffer);
+}
+
+/**
+ * The synchronous counterpart of `createZipArchive()`. `entries` must be a
+ * plain (synchronous) `Iterable` of entries that don't require an
+ * asynchronous serialization pass - a streaming entry created with
+ * `ZipEntry.createStream()` throws when its turn to serialize comes up, the
+ * same as calling `entry[Symbol.iterator]()` on one directly. Blocks the
+ * event loop and further JavaScript execution until the whole archive
+ * (including any deflate passes) has been produced; see
+ * `zipEntry.contentSync()`.
+ * @param {Iterable<ZipEntry>} entries
+ * @param {string | { comment?: string, baseOffset?: number }} [options]
+ * @yields {Buffer}
+ */
+function* createZipArchiveSync(entries, options) {
+  const { comment, baseOffset } = normalizeArchiveOptions(options);
+  let commentBuffer = EMPTY_BUFFER;
+  if (comment !== undefined) {
+    commentBuffer = Buffer.from(comment, 'utf8');
+    if (commentBuffer.length > SENTINEL16) {
+      throw new ERR_ZIP_ENTRY_TOO_LARGE(
+        'the archive comment must not exceed 65535 bytes when encoded as UTF-8');
+    }
+  }
+  const centralHeaders = [];
+  let pos = baseOffset;
+  for (const entry of entries) {
+    const start = pos;
+    for (const chunk of entry) {
+      yield chunk;
+      pos += chunk.length;
+    }
+    ArrayPrototypePush(centralHeaders, entry[kFinalize](start));
+  }
+  const centralDirectoryOffset = pos;
+  for (let i = 0; i < centralHeaders.length; i++) {
+    const chunk = centralHeaders[i];
+    yield chunk;
+    pos += chunk.length;
+  }
+  const centralDirectorySize = pos - centralDirectoryOffset;
+  const count = centralHeaders.length;
+  const zip64 =
+    count >= SENTINEL16 ||
+    centralDirectoryOffset >= SENTINEL32 ||
+    centralDirectorySize >= SENTINEL32;
+  if (zip64) {
+    const recordOffset = pos;
+    yield buildZip64EndRecord(count, centralDirectorySize, centralDirectoryOffset);
+    yield buildZip64EndLocator(recordOffset);
+  }
+  yield buildEndOfCentralDirectory(
+    count, centralDirectorySize, centralDirectoryOffset, commentBuffer);
+}
+
+/**
+ * An in-memory view over the entries of a ZIP archive, writable in place:
+ * entries can be added or removed, and `toBuffer()` serializes the current
+ * set of entries into a fresh archive.
+ */
+class ZipBuffer {
+  #entries = new Map();
+  #comment;
+
+  /**
+   * @param {Buffer | TypedArray | DataView | ArrayBuffer} buffer
+   */
+  constructor(buffer) {
+    const buf = toBuffer(buffer, 'buffer');
+    this.#comment = findArchiveEnd(buf).comment;
+    for (const entry of ZipEntry.read(buf)) {
+      MapPrototypeSet(this.#entries, entry.name, entry);
+    }
+  }
+  get writable() { return true; }
+  get comment() { return this.#comment.toString('utf8'); }
+  has(name) {
+    validateString(name, 'name');
+    return MapPrototypeHas(this.#entries, name);
+  }
+  get(name) {
+    validateString(name, 'name');
+    const entry = MapPrototypeGet(this.#entries, name);
+    if (entry === undefined) throw new ERR_ZIP_ENTRY_NOT_FOUND(name);
+    return entry;
+  }
+  /**
+   * Adds an already-built entry, keyed by its own name (replacing any
+   * existing entry of that name).
+   * @param {ZipEntry} entry
+   * @returns {ZipEntry}
+   */
+  addEntry(entry) {
+    if (!(entry instanceof ZipEntry)) {
+      throw new ERR_INVALID_ARG_TYPE('entry', 'ZipEntry', entry);
+    }
+    MapPrototypeSet(this.#entries, entry.name, entry);
+    return entry;
+  }
+  /**
+   * @param {string} filename
+   * @param {Buffer | TypedArray | DataView | ArrayBuffer} data
+   * @param {{ comment?: string, mode?: number, modified?: Date, method?: 'deflate' | 'store' | 'zstd' }} [options]
+   * @returns {Promise<ZipEntry>}
+   */
+  async add(filename, data, options) {
+    return this.addEntry(await ZipEntry.create(filename, data, options));
+  }
+  /**
+   * The synchronous counterpart of `add()`. Blocks the event loop and
+   * further JavaScript execution until done; see `zipEntry.contentSync()`.
+   * @param {string} filename
+   * @param {Buffer | TypedArray | DataView | ArrayBuffer} data
+   * @param {{ comment?: string, mode?: number, modified?: Date, method?: 'deflate' | 'store' | 'zstd' }} [options]
+   * @returns {ZipEntry}
+   */
+  addSync(filename, data, options) {
+    return this.addEntry(ZipEntry.createSync(filename, data, options));
+  }
+  /**
+   * @param {string} name
+   * @returns {boolean}
+   */
+  delete(name) {
+    validateString(name, 'name');
+    return MapPrototypeDelete(this.#entries, name);
+  }
+  clear() {
+    MapPrototypeClear(this.#entries);
+  }
+  keys() { return MapPrototypeKeys(this.#entries); }
+  *values() {
+    for (const name of this.keys()) yield this.get(name);
+  }
+  *entries() {
+    for (const name of this.keys()) yield [name, this.get(name)];
+  }
+  get size() { return MapPrototypeGetSize(this.#entries); }
+  [SymbolIterator]() { return this.entries(); }
+  get [SymbolToStringTag]() { return 'ZipBuffer'; }
+  forEach(callback, thisArg) {
+    validateFunction(callback, 'callback');
+    for (const { 0: key, 1: value } of MapPrototypeEntries(this.#entries)) {
+      FunctionPrototypeCall(callback, thisArg === undefined ? this : thisArg, value, key, this);
+    }
+  }
+  /**
+   * Serializes the current set of entries into a fresh archive.
+   * @param {string | { comment?: string, baseOffset?: number }} [options]
+   * @returns {Promise<Buffer>}
+   */
+  async toBuffer(options) {
+    const { comment, baseOffset } = normalizeArchiveOptions(options);
+    const chunks = [];
+    for await (const chunk of createZipArchive(this.values(), { comment: comment ?? this.comment, baseOffset })) {
+      ArrayPrototypePush(chunks, chunk);
+    }
+    return Buffer.concat(chunks);
+  }
+  /**
+   * The synchronous counterpart of `toBuffer()`. Blocks the event loop and
+   * further JavaScript execution until the whole archive has been
+   * serialized; see `zipEntry.contentSync()`.
+   * @param {string | { comment?: string, baseOffset?: number }} [options]
+   * @returns {Buffer}
+   */
+  toBufferSync(options) {
+    const { comment, baseOffset } = normalizeArchiveOptions(options);
+    const chunks = [];
+    for (const chunk of createZipArchiveSync(this.values(), { comment: comment ?? this.comment, baseOffset })) {
+      ArrayPrototypePush(chunks, chunk);
+    }
+    return Buffer.concat(chunks);
+  }
+  [SymbolDispose]() {
+    MapPrototypeClear(this.#entries);
+  }
+}
+
+const READ_CHUNK_SIZE = 4 * 1024 * 1024;
+// EOCD + max comment + Zip64 locator + Zip64 record + slack for an
+// extensible data sector.
+const TAIL_LENGTH = 22 + SENTINEL16 + 20 + 56 + 4096;
+
+// `ZipFile` operates on a plain numeric file descriptor (rather than an
+// `fs.promises` `FileHandle`) so that a single instance can support both the
+// async and the `Sync` methods: `fs.read`/`fs.write`/`fs.fstat`/
+// `fs.ftruncate`/`fs.close` all accept a raw fd directly, same as their
+// `*Sync` counterparts, so both call sites share one open file underneath.
+function fsOpenAsync(path, flag) {
+  return new Promise((resolve, reject) => {
+    fs.open(path, flag, (err, fd) => (err ? reject(err) : resolve(fd)));
+  });
+}
+
+function fsCloseAsync(fd) {
+  return new Promise((resolve, reject) => {
+    fs.close(fd, (err) => (err ? reject(err) : resolve()));
+  });
+}
+
+function fsFstatAsync(fd) {
+  return new Promise((resolve, reject) => {
+    fs.fstat(fd, (err, stats) => (err ? reject(err) : resolve(stats)));
+  });
+}
+
+function fsReadAsync(fd, buffer, offset, length, position) {
+  return new Promise((resolve, reject) => {
+    fs.read(fd, buffer, offset, length, position, (err, bytesRead) => (err ? reject(err) : resolve(bytesRead)));
+  });
+}
+
+function fsWriteAsync(fd, buffer, offset, length, position) {
+  return new Promise((resolve, reject) => {
+    fs.write(fd, buffer, offset, length, position, (err, bytesWritten) => (err ? reject(err) : resolve(bytesWritten)));
+  });
+}
+
+function fsFtruncateAsync(fd, len) {
+  return new Promise((resolve, reject) => {
+    fs.ftruncate(fd, len, (err) => (err ? reject(err) : resolve()));
+  });
+}
+
+async function readFdFully(fd, buffer, position) {
+  let done = 0;
+  while (done < buffer.length) {
+    const bytesRead = await fsReadAsync(fd, buffer, done, buffer.length - done, position + done);
+    if (bytesRead <= 0) {
+      throw new ERR_ZIP_INVALID_ARCHIVE('unexpected end of file');
+    }
+    done += bytesRead;
+  }
+}
+
+function readFdFullySync(fd, buffer, position) {
+  let done = 0;
+  while (done < buffer.length) {
+    const bytesRead = fs.readSync(fd, buffer, done, buffer.length - done, position + done);
+    if (bytesRead <= 0) {
+      throw new ERR_ZIP_INVALID_ARCHIVE('unexpected end of file');
+    }
+    done += bytesRead;
+  }
+}
+
+function readCentralDirectory(buffer, count) {
+  const result = [];
+  let pos = 0;
+  for (let index = 0; index < count; index++) {
+    const header = new CentralFileHeader(buffer, pos);
+    if (header.diskNumber !== 0) {
+      throw new ERR_ZIP_UNSUPPORTED_FEATURE('multi-disk archives are not supported');
+    }
+    ArrayPrototypePush(result, header);
+    pos += header.byteLength;
+  }
+  return result;
+}
+
+/**
+ * Builds a fresh central directory (plus Zip64 structures and EOCD, as
+ * needed) for `records`, an array of `{ entry, localOffset }` pairs already
+ * in their final order and at their final (possibly pre-existing, possibly
+ * freshly written) offsets.
+ * @param {Array<{ entry: ZipEntry, localOffset: number }>} records
+ * @param {number} centralDirectoryOffset
+ * @param {Buffer} comment
+ * @returns {{ centralHeaders: Buffer[], chunks: Buffer[] }}
+ */
+function buildCentralDirectoryChunks(records, centralDirectoryOffset, comment) {
+  const centralHeaders = [];
+  let centralDirectorySize = 0;
+  for (let i = 0; i < records.length; i++) {
+    const header = records[i].entry[kFinalize](records[i].localOffset);
+    ArrayPrototypePush(centralHeaders, header);
+    centralDirectorySize += header.length;
+  }
+  const count = records.length;
+  const zip64 =
+    count >= SENTINEL16 ||
+    centralDirectoryOffset >= SENTINEL32 ||
+    centralDirectorySize >= SENTINEL32;
+  const chunks = [];
+  for (let i = 0; i < centralHeaders.length; i++) ArrayPrototypePush(chunks, centralHeaders[i]);
+  if (zip64) {
+    const recordOffset = centralDirectoryOffset + centralDirectorySize;
+    ArrayPrototypePush(chunks, buildZip64EndRecord(count, centralDirectorySize, centralDirectoryOffset));
+    ArrayPrototypePush(chunks, buildZip64EndLocator(recordOffset));
+  }
+  ArrayPrototypePush(
+    chunks, buildEndOfCentralDirectory(count, centralDirectorySize, centralDirectoryOffset, comment));
+  return { centralHeaders, chunks };
+}
+
+/**
+ * A random-access view over the entries of a ZIP archive on disk. Only the
+ * archive tail and central directory are read up front; individual member
+ * content is read lazily and on demand. Writable when opened with
+ * `{ writable: true }`: adding or deleting an entry rewrites the central
+ * directory in place, appending new entry content where the old central
+ * directory used to be.
+ *
+ * Every method has a `*Sync` counterpart. The synchronous methods block the
+ * Node.js event loop and further JavaScript execution until the operation
+ * completes - use them only where synchronous I/O is appropriate (for
+ * example, short-lived scripts or startup code), never in code that must
+ * stay responsive. A synchronous method throws `ERR_INVALID_STATE` if called
+ * while an asynchronous `addEntry()`/`add()`/`delete()`/`close()` on the same
+ * `ZipFile` has not settled yet, since letting the two interleave could
+ * corrupt the archive.
+ */
+class ZipFile {
+  #fd;
+  #writable;
+  #comment;
+  #centralDirectoryOffset;
+  #entries = new Map();
+  #queue = PromiseResolve();
+  #pendingAsyncOps = 0;
+
+  /**
+   * @private
+   */
+  constructor(fd, centralHeaders, prefix, centralDirectoryOffset, comment, writable) {
+    this.#fd = fd;
+    this.#writable = writable;
+    this.#comment = comment;
+    this.#centralDirectoryOffset = centralDirectoryOffset;
+    for (let i = 0; i < centralHeaders.length; i++) {
+      const central = centralHeaders[i];
+      MapPrototypeSet(this.#entries, central.fileName, {
+        central,
+        entry: undefined,
+        localOffset: central.localFileHeaderOffset + prefix,
+      });
+    }
+  }
+  get writable() { return this.#writable; }
+  get comment() { return this.#comment.toString('utf8'); }
+  #assertWritable() {
+    if (!this.#writable) throw new ERR_ZIP_NOT_WRITABLE();
+  }
+  #assertNotBusy() {
+    if (this.#pendingAsyncOps > 0) {
+      throw new ERR_INVALID_STATE(
+        'cannot call a synchronous ZipFile method while an asynchronous ' +
+        'add(), addEntry(), delete(), or close() call has not settled yet');
+    }
+  }
+  #enqueue(fn) {
+    this.#pendingAsyncOps++;
+    const run = async () => {
+      try {
+        return await fn();
+      } finally {
+        this.#pendingAsyncOps--;
+      }
+    };
+    const result = PromisePrototypeThen(this.#queue, run, run);
+    this.#queue = PromisePrototypeThen(result, () => undefined, () => undefined);
+    return result;
+  }
+  has(name) {
+    validateString(name, 'name');
+    return MapPrototypeHas(this.#entries, name);
+  }
+  // Return the lazy, file-backed ZipEntry handle for `info`, creating and
+  // caching it on first access. The handle stores only a descriptor and the
+  // local-header offset - never the member's content - so repeated `get()`s
+  // return the same lightweight object and no content buffer is retained by
+  // the ZipFile. Any read (`content()`, `contentIterator()`) goes to disk.
+  #handleFor(info) {
+    info.entry ??= new ZipEntry(info.central, null, null, this.#fd, info.localOffset);
+    return info.entry;
+  }
+  /**
+   * Returns a lazy, file-backed `ZipEntry` for `name`. Nothing is read from
+   * disk here and no content is buffered; the entry reads (and, for
+   * `content()`, decompresses) straight from the file on each access. The
+   * returned entry is valid only while this `ZipFile` is open.
+   * @param {string} name
+   * @returns {Promise<ZipEntry>}
+   */
+  async get(name) {
+    validateString(name, 'name');
+    const info = MapPrototypeGet(this.#entries, name);
+    if (info === undefined) throw new ERR_ZIP_ENTRY_NOT_FOUND(name);
+    return this.#handleFor(info);
+  }
+  /**
+   * The synchronous counterpart of `get()`. Like `get()`, it reads nothing
+   * up front and buffers no content - it only builds the lazy handle - so it
+   * does not itself block on I/O; see the class-level note on synchronous
+   * methods for reads performed later through the returned entry.
+   * @param {string} name
+   * @returns {ZipEntry}
+   */
+  getSync(name) {
+    this.#assertNotBusy();
+    validateString(name, 'name');
+    const info = MapPrototypeGet(this.#entries, name);
+    if (info === undefined) throw new ERR_ZIP_ENTRY_NOT_FOUND(name);
+    return this.#handleFor(info);
+  }
+  /**
+   * Streams a member's decoded content without buffering the whole member,
+   * as a `Readable` (verifying CRC-32 by default; `{ verify: false }` to opt
+   * out). Sugar for wrapping `get(name).contentIterator(options)`; the
+   * compressed bytes are read from disk as the stream is consumed.
+   * @param {string} name
+   * @param {{ verify?: boolean, maxSize?: number }} [options]
+   * @returns {Promise<import('stream').Readable>}
+   */
+  async stream(name, options) {
+    const entry = await this.get(name);
+    return Readable.from(entry.contentIterator(options), { objectMode: false });
+  }
+  /**
+   * Writes `entry`'s serialized bytes where the central directory currently
+   * starts, then rewrites the central directory to include it. Replaces any
+   * existing entry of the same name (its bytes become dead space, reclaimed
+   * by `compact()`).
+   * @param {ZipEntry} entry
+   * @returns {Promise<ZipEntry>}
+   */
+  async addEntry(entry) {
+    this.#assertWritable();
+    if (!(entry instanceof ZipEntry)) {
+      throw new ERR_INVALID_ARG_TYPE('entry', 'ZipEntry', entry);
+    }
+    return this.#enqueue(() => this.#doAdd(entry));
+  }
+  /**
+   * @param {string} filename
+   * @param {Buffer | TypedArray | DataView | ArrayBuffer} data
+   * @param {{ comment?: string, mode?: number, modified?: Date, method?: 'deflate' | 'store' | 'zstd' }} [options]
+   * @returns {Promise<ZipEntry>}
+   */
+  async add(filename, data, options) {
+    this.#assertWritable();
+    return this.addEntry(await ZipEntry.create(filename, data, options));
+  }
+  async #doAdd(entry) {
+    const localOffset = this.#centralDirectoryOffset;
+    let written = 0;
+    for await (const chunk of entry) {
+      await fsWriteAsync(this.#fd, chunk, 0, chunk.length, localOffset + written);
+      written += chunk.length;
+    }
+    this.#centralDirectoryOffset = localOffset + written;
+    MapPrototypeSet(this.#entries, entry.name, { central: null, entry, localOffset });
+    await this.#rewriteCentralDirectory();
+    // The entry now has a stable home in this archive; if it was a spent
+    // streaming entry, rebind it to that on-disk copy so it stays readable.
+    entry[kPromote](this.#fd, localOffset);
+    return entry;
+  }
+  /**
+   * The synchronous counterpart of `addEntry()`. `entry` must not be a
+   * pending streaming entry (one created with `ZipEntry.createStream()`) -
+   * there is no synchronous way to drain its asynchronous source. Blocks the
+   * event loop until done; see the class-level note on synchronous methods.
+   * @param {ZipEntry} entry
+   * @returns {ZipEntry}
+   */
+  addEntrySync(entry) {
+    this.#assertWritable();
+    this.#assertNotBusy();
+    if (!(entry instanceof ZipEntry)) {
+      throw new ERR_INVALID_ARG_TYPE('entry', 'ZipEntry', entry);
+    }
+    const localOffset = this.#centralDirectoryOffset;
+    let written = 0;
+    for (const chunk of entry) {
+      fs.writeSync(this.#fd, chunk, 0, chunk.length, localOffset + written);
+      written += chunk.length;
+    }
+    this.#centralDirectoryOffset = localOffset + written;
+    MapPrototypeSet(this.#entries, entry.name, { central: null, entry, localOffset });
+    this.#rewriteCentralDirectorySync();
+    entry[kPromote](this.#fd, localOffset);
+    return entry;
+  }
+  /**
+   * The synchronous counterpart of `add()`. Blocks the event loop until
+   * done (including the deflate pass); see the class-level note on
+   * synchronous methods.
+   * @param {string} filename
+   * @param {Buffer | TypedArray | DataView | ArrayBuffer} data
+   * @param {{ comment?: string, mode?: number, modified?: Date, method?: 'deflate' | 'store' | 'zstd' }} [options]
+   * @returns {ZipEntry}
+   */
+  addSync(filename, data, options) {
+    this.#assertWritable();
+    return this.addEntrySync(ZipEntry.createSync(filename, data, options));
+  }
+  /**
+   * Removes an entry by name. The central directory is rewritten in place
+   * (no new content is written, so the archive does not grow); the removed
+   * entry's bytes become dead space, reclaimed by `compact()`.
+   * @param {string} name
+   * @returns {Promise<boolean>}
+   */
+  async delete(name) {
+    this.#assertWritable();
+    validateString(name, 'name');
+    return this.#enqueue(() => this.#doDelete(name));
+  }
+  async #doDelete(name) {
+    const existed = MapPrototypeDelete(this.#entries, name);
+    if (existed) await this.#rewriteCentralDirectory();
+    return existed;
+  }
+  /**
+   * The synchronous counterpart of `delete()`. Blocks the event loop until
+   * done; see the class-level note on synchronous methods.
+   * @param {string} name
+   * @returns {boolean}
+   */
+  deleteSync(name) {
+    this.#assertWritable();
+    this.#assertNotBusy();
+    validateString(name, 'name');
+    const existed = MapPrototypeDelete(this.#entries, name);
+    if (existed) this.#rewriteCentralDirectorySync();
+    return existed;
+  }
+  #liveRecords() {
+    const records = [];
+    const names = [];
+    for (const { 0: name, 1: value } of MapPrototypeEntries(this.#entries)) {
+      ArrayPrototypePush(records, {
+        entry: value.entry ?? new ZipEntry(value.central, null, null),
+        localOffset: value.localOffset,
+      });
+      ArrayPrototypePush(names, name);
+    }
+    return { records, names };
+  }
+  async #rewriteCentralDirectory() {
+    const { records, names } = this.#liveRecords();
+    const { centralHeaders, chunks } = buildCentralDirectoryChunks(
+      records, this.#centralDirectoryOffset, this.#comment);
+    let pos = this.#centralDirectoryOffset;
+    for (let i = 0; i < chunks.length; i++) {
+      await fsWriteAsync(this.#fd, chunks[i], 0, chunks[i].length, pos);
+      pos += chunks[i].length;
+    }
+    await fsFtruncateAsync(this.#fd, pos);
+    this.#adoptRewrittenCentralDirectory(names, centralHeaders, records);
+  }
+  #rewriteCentralDirectorySync() {
+    const { records, names } = this.#liveRecords();
+    const { centralHeaders, chunks } = buildCentralDirectoryChunks(
+      records, this.#centralDirectoryOffset, this.#comment);
+    let pos = this.#centralDirectoryOffset;
+    for (let i = 0; i < chunks.length; i++) {
+      fs.writeSync(this.#fd, chunks[i], 0, chunks[i].length, pos);
+      pos += chunks[i].length;
+    }
+    fs.ftruncateSync(this.#fd, pos);
+    this.#adoptRewrittenCentralDirectory(names, centralHeaders, records);
+  }
+  // Re-derives fresh, disk-backed central headers from what was just
+  // written, so every entry - original or freshly added - is uniformly
+  // readable by offset from now on, regardless of whether its in-memory
+  // ZipEntry (e.g. a streaming entry, whose source can only be consumed
+  // once) is still around.
+  #adoptRewrittenCentralDirectory(names, centralHeaders, records) {
+    for (let i = 0; i < names.length; i++) {
+      MapPrototypeSet(this.#entries, names[i], {
+        central: new CentralFileHeader(centralHeaders[i], 0),
+        entry: undefined,
+        localOffset: records[i].localOffset,
+      });
+    }
+  }
+  /**
+   * Serializes the currently live entries into a fresh archive stream,
+   * leaving behind any dead space left by prior `addEntry()`/`delete()`
+   * calls. Does not modify the open file; pipe the result into a new one.
+   * @param {string} [comment]
+   * @returns {import('stream').Readable}
+   */
+  compact(comment) {
+    const self = this;
+    async function* liveEntries() {
+      for (const name of self.keys()) {
+        yield await self.get(name);
+      }
+    }
+    return createZipArchive(liveEntries(), comment ?? this.comment);
+  }
+  /**
+   * The synchronous counterpart of `compact()`. Blocks the event loop until
+   * the whole archive has been read and re-serialized; see the class-level
+   * note on synchronous methods.
+   * @param {string} [comment]
+   * @returns {Buffer}
+   */
+  compactSync(comment) {
+    this.#assertNotBusy();
+    const self = this;
+    function* liveEntries() {
+      for (const name of self.keys()) yield self.getSync(name);
+    }
+    const chunks = [];
+    for (const chunk of createZipArchiveSync(liveEntries(), comment ?? this.comment)) {
+      ArrayPrototypePush(chunks, chunk);
+    }
+    return Buffer.concat(chunks);
+  }
+  keys() { return MapPrototypeKeys(this.#entries); }
+  *values() {
+    for (const name of this.keys()) yield this.get(name);
+  }
+  /**
+   * The synchronous counterpart of `values()`, yielding resolved `ZipEntry`
+   * values instead of `Promise`s.
+   * @yields {ZipEntry}
+   */
+  *valuesSync() {
+    for (const name of this.keys()) yield this.getSync(name);
+  }
+  *entries() {
+    for (const name of this.keys()) yield [name, this.get(name)];
+  }
+  /**
+   * The synchronous counterpart of `entries()`, yielding resolved `ZipEntry`
+   * values instead of `Promise`s.
+   * @yields {[string, ZipEntry]}
+   */
+  *entriesSync() {
+    for (const name of this.keys()) yield [name, this.getSync(name)];
+  }
+  async *[SymbolAsyncIterator]() {
+    for (const promise of this.values()) yield await promise;
+  }
+  get size() { return MapPrototypeGetSize(this.#entries); }
+  [SymbolIterator]() { return this.entries(); }
+  get [SymbolToStringTag]() { return 'ZipFile'; }
+  forEach(callback, thisArg) {
+    validateFunction(callback, 'callback');
+    for (const { 0: key, 1: value } of this.entries()) {
+      FunctionPrototypeCall(callback, thisArg === undefined ? this : thisArg, value, key, this);
+    }
+  }
+  /**
+   * The synchronous counterpart of `forEach()`, invoking `callback` with a
+   * resolved `ZipEntry` instead of a `Promise`.
+   * @param {Function} callback
+   * @param {*} [thisArg]
+   */
+  forEachSync(callback, thisArg) {
+    validateFunction(callback, 'callback');
+    for (const { 0: key, 1: value } of this.entriesSync()) {
+      FunctionPrototypeCall(callback, thisArg === undefined ? this : thisArg, value, key, this);
+    }
+  }
+  close() {
+    return this.#enqueue(async () => {
+      MapPrototypeClear(this.#entries);
+      await fsCloseAsync(this.#fd);
+    });
+  }
+  /**
+   * The synchronous counterpart of `close()`; see the class-level note on
+   * synchronous methods.
+   */
+  closeSync() {
+    this.#assertNotBusy();
+    MapPrototypeClear(this.#entries);
+    fs.closeSync(this.#fd);
+  }
+  async [SymbolAsyncDispose]() {
+    await this.close();
+  }
+  [SymbolDispose]() {
+    this.closeSync();
+  }
+  /**
+   * @param {string} filename
+   * @param {{ writable?: boolean }} [options]
+   * @returns {Promise<ZipFile>}
+   */
+  static async open(filename, options) {
+    validateString(filename, 'filename');
+    const writable = options?.writable ?? false;
+    validateBoolean(writable, 'options.writable');
+    const fd = await fsOpenAsync(filename, writable ? 'r+' : 'r');
+    try {
+      const stat = await fsFstatAsync(fd);
+      const size = stat.size;
+      const tailLength = MathMin(size, TAIL_LENGTH);
+      const tail = Buffer.allocUnsafe(tailLength);
+      await readFdFully(fd, tail, size - tailLength);
+      const end = findArchiveEnd(tail, size - tailLength);
+      if (end.centralDirectorySize > kMaxLength) {
+        throw new ERR_ZIP_ENTRY_TOO_LARGE('the central directory is too large to buffer');
+      }
+      if (end.centralDirectoryOffset + end.centralDirectorySize > size) {
+        throw new ERR_ZIP_INVALID_ARCHIVE('central directory is out of bounds');
+      }
+      const directory = Buffer.allocUnsafe(end.centralDirectorySize);
+      await readFdFully(fd, directory, end.centralDirectoryOffset);
+      const headers = readCentralDirectory(directory, end.totalRecords);
+      return new ZipFile(fd, headers, end.prefix, end.centralDirectoryOffset, end.comment, writable);
+    } catch (err) {
+      try {
+        await fsCloseAsync(fd);
+      } catch {
+        // The archive failed to parse; the close error is not actionable.
+      }
+      throw err;
+    }
+  }
+  /**
+   * The synchronous counterpart of `open()`. Blocks the event loop and
+   * further JavaScript execution until the archive's tail and central
+   * directory have been read; see the class-level note on synchronous
+   * methods.
+   * @param {string} filename
+   * @param {{ writable?: boolean }} [options]
+   * @returns {ZipFile}
+   */
+  static openSync(filename, options) {
+    validateString(filename, 'filename');
+    const writable = options?.writable ?? false;
+    validateBoolean(writable, 'options.writable');
+    const fd = fs.openSync(filename, writable ? 'r+' : 'r');
+    try {
+      const size = fs.fstatSync(fd).size;
+      const tailLength = MathMin(size, TAIL_LENGTH);
+      const tail = Buffer.allocUnsafe(tailLength);
+      readFdFullySync(fd, tail, size - tailLength);
+      const end = findArchiveEnd(tail, size - tailLength);
+      if (end.centralDirectorySize > kMaxLength) {
+        throw new ERR_ZIP_ENTRY_TOO_LARGE('the central directory is too large to buffer');
+      }
+      if (end.centralDirectoryOffset + end.centralDirectorySize > size) {
+        throw new ERR_ZIP_INVALID_ARCHIVE('central directory is out of bounds');
+      }
+      const directory = Buffer.allocUnsafe(end.centralDirectorySize);
+      readFdFullySync(fd, directory, end.centralDirectoryOffset);
+      const headers = readCentralDirectory(directory, end.totalRecords);
+      return new ZipFile(fd, headers, end.prefix, end.centralDirectoryOffset, end.comment, writable);
+    } catch (err) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        // The archive failed to parse; the close error is not actionable.
+      }
+      throw err;
+    }
+  }
+}
+
+module.exports = {
+  ZipEntry,
+  ZipFile,
+  ZipBuffer,
+  createZipArchive,
+  createZipArchiveSync,
+  getMaxZipContentSize,
+  setMaxZipContentSize,
+};

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -71,6 +71,15 @@ const {
   validateFiniteNumber,
 } = require('internal/validators');
 const { FastBuffer } = require('internal/buffer');
+const {
+  ZipEntry,
+  ZipFile,
+  ZipBuffer,
+  createZipArchive,
+  createZipArchiveSync,
+  getMaxZipContentSize,
+  setMaxZipContentSize,
+} = require('internal/zip');
 
 const kFlushFlag = Symbol('kFlushFlag');
 const kError = Symbol('kError');
@@ -1015,6 +1024,15 @@ module.exports = {
   BrotliDecompress,
   ZstdCompress,
   ZstdDecompress,
+
+  // ZIP archive support.
+  ZipEntry,
+  ZipFile,
+  ZipBuffer,
+  createZipArchive,
+  createZipArchiveSync,
+  getMaxZipContentSize,
+  setMaxZipContentSize,
 
   // Convenience methods.
   // compress/decompress a string or buffer in one step.

--- a/test/parallel/test-zlib-zip-coverage.js
+++ b/test/parallel/test-zlib-zip-coverage.js
@@ -1,0 +1,840 @@
+'use strict';
+
+require('../common');
+
+const assert = require('node:assert');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs/promises');
+const zlib = require('node:zlib');
+const { test } = require('node:test');
+
+// Additional zip.js coverage beyond the other test-zlib-zip-*.js files:
+// DOS date/time edge cases, the Zip64 extra-field parser's normal and
+// out-of-range paths, the "data was prepended to the archive" central
+// directory recovery scan, buffer-coercion variants, entry-metadata
+// validation, streaming-entry state guards, the ZipBuffer/ZipFile
+// iteration protocols, and several ZipFile (on-disk) error paths that
+// aren't reachable through ZipBuffer alone.
+
+async function buildArchive(entries, comment) {
+  const chunks = [];
+  for await (const chunk of zlib.createZipArchive(entries, comment)) chunks.push(chunk);
+  return Buffer.concat(chunks);
+}
+
+async function drain(iterable) {
+  const chunks = [];
+  for await (const chunk of iterable) chunks.push(chunk);
+  return Buffer.concat(chunks);
+}
+
+// -- DOS date/time -----------------------------------------------------------
+
+test('a zeroed DOS date/time field decodes to the 1980-01-01 epoch', async () => {
+  const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('hi'), { method: 'store' });
+  const archive = await buildArchive([entry]);
+  const tampered = Buffer.from(archive);
+  tampered.writeUInt16LE(0, 10); // local time
+  tampered.writeUInt16LE(0, 12); // local date
+  const centralStart = 30 + 'f.txt'.length + 'hi'.length;
+  tampered.writeUInt16LE(0, centralStart + 12); // central time
+  tampered.writeUInt16LE(0, centralStart + 14); // central date
+
+  const [read] = zlib.ZipEntry.read(tampered);
+  assert.strictEqual(read.modified.getTime(), new Date(1980, 0, 1, 0, 0, 0).getTime());
+});
+
+test('serializing an entry with an invalid modified Date is rejected', async () => {
+  const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('hi'), { modified: new Date(NaN) });
+  await assert.rejects(buildArchive([entry]), { code: 'ERR_INVALID_ARG_VALUE' });
+});
+
+// -- Zip64 structures ---------------------------------------------------------
+
+function buildZip64Record({ diskNumber = 0, cdDiskNumber = 0, cdDiskRecords = 0n,
+                            cdTotalRecords = 0n, cdSize = 0n, cdOffset = 0n } = {}) {
+  const buf = Buffer.allocUnsafe(56);
+  buf.writeUInt32LE(0x06064b50, 0);
+  buf.writeBigUInt64LE(44n, 4);
+  buf.writeUInt16LE((3 << 8) | 45, 12); // Made by Unix, version 4.5
+  buf.writeUInt16LE(45, 14);
+  buf.writeUInt32LE(diskNumber, 16);
+  buf.writeUInt32LE(cdDiskNumber, 20);
+  buf.writeBigUInt64LE(cdDiskRecords, 24);
+  buf.writeBigUInt64LE(cdTotalRecords, 32);
+  buf.writeBigUInt64LE(cdSize, 40);
+  buf.writeBigUInt64LE(cdOffset, 48);
+  return buf;
+}
+
+function buildZip64Locator({ recordDiskNumber = 0, recordOffset = 0n, totalDisks = 1 } = {}) {
+  const buf = Buffer.allocUnsafe(20);
+  buf.writeUInt32LE(0x07064b50, 0);
+  buf.writeUInt32LE(recordDiskNumber, 4);
+  buf.writeBigUInt64LE(recordOffset, 8);
+  buf.writeUInt32LE(totalDisks, 16);
+  return buf;
+}
+
+function buildEocd({ diskNumber = 0, cdDiskNumber = 0, cdDiskRecords = 0,
+                     totalRecords = 0, cdSize = 0, cdOffset = 0, comment = Buffer.alloc(0) } = {}) {
+  const buf = Buffer.allocUnsafe(22 + comment.length);
+  buf.writeUInt32LE(0x06054b50, 0);
+  buf.writeUInt16LE(diskNumber, 4);
+  buf.writeUInt16LE(cdDiskNumber, 6);
+  buf.writeUInt16LE(cdDiskRecords, 8);
+  buf.writeUInt16LE(totalRecords, 10);
+  buf.writeUInt32LE(cdSize, 12);
+  buf.writeUInt32LE(cdOffset, 16);
+  buf.writeUInt16LE(comment.length, 20);
+  comment.copy(buf, 22);
+  return buf;
+}
+
+// A minimal (zero-entry) Zip64 archive: record + locator + classic EOCD,
+// with the locator pointing directly at the record.
+function buildMinimalZip64Archive({ record, locator, eocd } = {}) {
+  return Buffer.concat([
+    buildZip64Record(record),
+    buildZip64Locator({ recordOffset: 0n, ...locator }),
+    buildEocd(eocd),
+  ]);
+}
+
+test('a well-formed minimal Zip64 archive round-trips its comment', () => {
+  const buf = buildMinimalZip64Archive({ eocd: { comment: Buffer.from('hi') } });
+  const zip = new zlib.ZipBuffer(buf);
+  assert.strictEqual(zip.size, 0);
+  assert.strictEqual(zip.comment, 'hi');
+});
+
+test('a Zip64 locator declaring more than one disk is rejected', () => {
+  const buf = buildMinimalZip64Archive({ locator: { totalDisks: 2 } });
+  assert.throws(() => [...zlib.ZipEntry.read(buf)], { code: 'ERR_ZIP_UNSUPPORTED_FEATURE' });
+});
+
+test('a Zip64 locator pointing at another disk is rejected', () => {
+  const buf = buildMinimalZip64Archive({ locator: { recordDiskNumber: 1 } });
+  assert.throws(() => [...zlib.ZipEntry.read(buf)], { code: 'ERR_ZIP_UNSUPPORTED_FEATURE' });
+});
+
+test('a Zip64 record on another disk is rejected', () => {
+  const buf = buildMinimalZip64Archive({ record: { diskNumber: 1 } });
+  assert.throws(() => [...zlib.ZipEntry.read(buf)], { code: 'ERR_ZIP_UNSUPPORTED_FEATURE' });
+});
+
+test('a Zip64 record with inconsistent disk record counts is rejected', () => {
+  const buf = buildMinimalZip64Archive({ record: { cdDiskRecords: 1n, cdTotalRecords: 2n } });
+  assert.throws(() => [...zlib.ZipEntry.read(buf)], { code: 'ERR_ZIP_UNSUPPORTED_FEATURE' });
+});
+
+test('a Zip64 record is found by scanning backward when data was prepended', () => {
+  // The locator's declared offset is wrong (as if the archive had been
+  // prepended with extra bytes, e.g. a self-extractor stub, after the
+  // record/locator were written), but the record still physically sits
+  // immediately before the locator; findArchiveEnd() must recover it.
+  const buf = buildMinimalZip64Archive({
+    locator: { recordOffset: 999_999n },
+    eocd: { comment: Buffer.from('recovered') },
+  });
+  const zip = new zlib.ZipBuffer(buf);
+  assert.strictEqual(zip.comment, 'recovered');
+});
+
+test('a Zip64 record that cannot be found anywhere is rejected', () => {
+  const buf = buildMinimalZip64Archive({ locator: { recordOffset: 999_999n } });
+  buf.writeUInt32LE(0xdeadbeef, 0); // Also corrupt the record actually present
+  assert.throws(() => [...zlib.ZipEntry.read(buf)], {
+    code: 'ERR_ZIP_INVALID_ARCHIVE',
+    message: /Zip64 end of central directory record not found/,
+  });
+});
+
+// Patches a single-entry, single-record archive's central header to carry a
+// synthetic Zip64 extra field for whichever of {uncompressedSize,
+// compressedSize, localFileHeaderOffset, diskNumber} are provided, setting
+// the corresponding 32-/16-bit field to the sentinel value that tells
+// CentralFileHeader to resolve it from the extra field instead. A leading,
+// unrelated TLV record is always included ahead of the Zip64 one, so the
+// "skip past a foreign record" loop iteration is exercised too.
+function injectZip64Extra(archive, name, contentLength, fields) {
+  const centralHeaderStart = 30 + name.length + contentLength;
+  const nameStart = centralHeaderStart + 46;
+  const extraLengthOffset = centralHeaderStart + 30;
+  assert.strictEqual(archive.readUInt16LE(extraLengthOffset), 0); // sanity: no existing extra
+
+  const dummyTlv = Buffer.from([0x99, 0x99, 0x04, 0x00, 0xde, 0xad, 0xbe, 0xef]);
+  const order = ['uncompressedSize', 'compressedSize', 'localFileHeaderOffset', 'diskNumber'];
+  const dataLength = order.reduce(
+    (total, key) => total + (key in fields ? (key === 'diskNumber' ? 4 : 8) : 0), 0);
+  const zip64Tlv = Buffer.allocUnsafe(4 + dataLength);
+  zip64Tlv.writeUInt16LE(0x0001, 0);
+  zip64Tlv.writeUInt16LE(dataLength, 2);
+  let pos = 4;
+  for (const key of order) {
+    if (!(key in fields)) continue;
+    if (key === 'diskNumber') {
+      zip64Tlv.writeUInt32LE(Number(fields[key]), pos);
+      pos += 4;
+    } else {
+      zip64Tlv.writeBigUInt64LE(BigInt(fields[key]), pos);
+      pos += 8;
+    }
+  }
+  const extra = Buffer.concat([dummyTlv, zip64Tlv]);
+
+  const before = archive.subarray(0, nameStart + name.length);
+  const after = archive.subarray(nameStart + name.length); // comment + EOCD
+  const patched = Buffer.concat([before, extra, after]);
+
+  patched.writeUInt16LE(extra.length, extraLengthOffset);
+  if ('uncompressedSize' in fields) patched.writeUInt32LE(0xffffffff, centralHeaderStart + 24);
+  if ('compressedSize' in fields) patched.writeUInt32LE(0xffffffff, centralHeaderStart + 20);
+  if ('localFileHeaderOffset' in fields) patched.writeUInt32LE(0xffffffff, centralHeaderStart + 42);
+  if ('diskNumber' in fields) patched.writeUInt16LE(0xffff, centralHeaderStart + 34);
+
+  const eocdOffset = patched.length - 22;
+  assert.strictEqual(patched.readUInt32LE(eocdOffset), 0x06054b50);
+  const oldCdSize = patched.readUInt32LE(eocdOffset + 12);
+  patched.writeUInt32LE(oldCdSize + extra.length, eocdOffset + 12);
+
+  return patched;
+}
+
+test('a foreign Zip64 extra field naming only the fields it needs still resolves', async () => {
+  const name = 'f.txt';
+  const content = Buffer.from('hello');
+  const entry = await zlib.ZipEntry.create(name, content, { method: 'store' });
+  const archive = await buildArchive([entry]);
+
+  const patched = injectZip64Extra(archive, name, content.length, {
+    uncompressedSize: content.length,
+    compressedSize: content.length,
+    localFileHeaderOffset: 0,
+    diskNumber: 0,
+  });
+
+  const [read] = zlib.ZipEntry.read(patched);
+  assert.strictEqual(read.size, content.length);
+  assert.strictEqual(read.compressedSize, content.length);
+  assert.strictEqual((await read.content()).toString(), 'hello');
+});
+
+test('a Zip64 extra field value beyond Number.MAX_SAFE_INTEGER is rejected', async () => {
+  const name = 'f.txt';
+  const content = Buffer.from('hello');
+  const entry = await zlib.ZipEntry.create(name, content, { method: 'store' });
+  const archive = await buildArchive([entry]);
+
+  const patched = injectZip64Extra(archive, name, content.length, {
+    uncompressedSize: 0xffffffffffffffffn,
+  });
+
+  const [read] = zlib.ZipEntry.read(patched);
+  assert.throws(() => read.size, {
+    code: 'ERR_ZIP_INVALID_ARCHIVE',
+    message: /exceeds the safe integer range/,
+  });
+});
+
+// Injects a raw, already-built Zip64 extra-field TLV (rather than one built
+// via injectZip64Extra()'s field map), to exercise the parser's own
+// malformed/truncated-input rejections.
+function injectRawZip64Extra(archive, name, contentLength, extraBytes) {
+  const centralHeaderStart = 30 + name.length + contentLength;
+  const nameStart = centralHeaderStart + 46;
+  const extraLengthOffset = centralHeaderStart + 30;
+  assert.strictEqual(archive.readUInt16LE(extraLengthOffset), 0);
+  const before = archive.subarray(0, nameStart + name.length);
+  const after = archive.subarray(nameStart + name.length);
+  const patched = Buffer.concat([before, extraBytes, after]);
+  patched.writeUInt16LE(extraBytes.length, extraLengthOffset);
+  patched.writeUInt32LE(0xffffffff, centralHeaderStart + 24); // uncompressedSize sentinel
+  const eocdOffset = patched.length - 22;
+  const oldCdSize = patched.readUInt32LE(eocdOffset + 12);
+  patched.writeUInt32LE(oldCdSize + extraBytes.length, eocdOffset + 12);
+  return patched;
+}
+
+test('a Zip64 extra-field TLV whose declared size overflows the extra field is rejected', async () => {
+  const name = 'f.txt';
+  const content = Buffer.from('hello');
+  const entry = await zlib.ZipEntry.create(name, content, { method: 'store' });
+  const archive = await buildArchive([entry]);
+
+  const tlv = Buffer.allocUnsafe(8);
+  tlv.writeUInt16LE(0x0001, 0);
+  tlv.writeUInt16LE(100, 2); // claims 100 bytes of data, but none follow
+  const patched = injectRawZip64Extra(archive, name, content.length, tlv);
+
+  const [read] = zlib.ZipEntry.read(patched);
+  assert.throws(() => read.size, {
+    code: 'ERR_ZIP_INVALID_ARCHIVE',
+    message: /extra field is malformed/,
+  });
+});
+
+test('a Zip64 extra-field TLV too short for the field it claims to carry is rejected', async () => {
+  const name = 'f.txt';
+  const content = Buffer.from('hello');
+  const entry = await zlib.ZipEntry.create(name, content, { method: 'store' });
+  const archive = await buildArchive([entry]);
+
+  // Declares only 4 bytes of data, but a sentinel uncompressedSize needs 8.
+  const tlv = Buffer.allocUnsafe(8);
+  tlv.writeUInt16LE(0x0001, 0);
+  tlv.writeUInt16LE(4, 2);
+  tlv.writeUInt32LE(123, 4);
+  const patched = injectRawZip64Extra(archive, name, content.length, tlv);
+
+  const [read] = zlib.ZipEntry.read(patched);
+  assert.throws(() => read.size, {
+    code: 'ERR_ZIP_INVALID_ARCHIVE',
+    message: /Zip64 extended information extra field is truncated/,
+  });
+});
+
+// -- buffer coercion -----------------------------------------------------------
+
+test('create() accepts a DataView, a non-Uint8Array TypedArray, and an ArrayBuffer', async () => {
+  const ab = new ArrayBuffer(4);
+  new Uint8Array(ab).set([1, 2, 3, 4]);
+
+  const dv = new DataView(ab, 1, 2);
+  const fromDataView = await zlib.ZipEntry.create('dv.bin', dv);
+  assert.strictEqual((await fromDataView.content()).length, 2);
+
+  const i32 = new Int32Array([10, 20, 30]);
+  const fromTypedArray = await zlib.ZipEntry.create('i32.bin', i32);
+  assert.strictEqual((await fromTypedArray.content()).length, 12);
+
+  const fromArrayBuffer = await zlib.ZipEntry.create('ab.bin', ab);
+  assert.strictEqual((await fromArrayBuffer.content()).length, 4);
+});
+
+// -- entry-metadata validation -------------------------------------------------
+
+test('create() validates comment length, modified type, and method value', async () => {
+  await assert.rejects(
+    zlib.ZipEntry.create('f.txt', Buffer.alloc(0), { comment: 'x'.repeat(70000) }),
+    { code: 'ERR_ZIP_ENTRY_TOO_LARGE' },
+  );
+  await assert.rejects(
+    zlib.ZipEntry.create('f.txt', Buffer.alloc(0), { modified: 123 }),
+    { code: 'ERR_INVALID_ARG_TYPE' },
+  );
+  await assert.rejects(
+    zlib.ZipEntry.create('f.txt', Buffer.alloc(0), { method: 'bogus' }),
+    { code: 'ERR_INVALID_ARG_VALUE' },
+  );
+});
+
+test('a directory entry must have empty content, for create(), createSync(), and createStream()', async () => {
+  await assert.rejects(
+    zlib.ZipEntry.create('dir/', Buffer.from('x')), { code: 'ERR_INVALID_ARG_VALUE' });
+  assert.throws(
+    () => zlib.ZipEntry.createSync('dir/', Buffer.from('x')), { code: 'ERR_INVALID_ARG_VALUE' });
+  assert.throws(
+    () => zlib.ZipEntry.createStream('dir/', (async function* () {})()), { code: 'ERR_INVALID_ARG_VALUE' });
+});
+
+test('createZipArchive()/createZipArchiveSync() validate the archive comment length', async () => {
+  await assert.rejects(drain(zlib.createZipArchive([], 'x'.repeat(70000))),
+                       { code: 'ERR_ZIP_ENTRY_TOO_LARGE' });
+  assert.throws(() => [...zlib.createZipArchiveSync([], 'x'.repeat(70000))],
+                { code: 'ERR_ZIP_ENTRY_TOO_LARGE' });
+});
+
+// -- streaming-entry state guards ----------------------------------------------
+
+test('a pending streaming entry rejects size/crc32/compressedSize/content access', () => {
+  const streaming = zlib.ZipEntry.createStream(
+    'big.bin', (async function* () { yield Buffer.from('x'); })());
+  assert.throws(() => streaming.size, { code: 'ERR_INVALID_STATE' });
+  assert.throws(() => streaming.crc32, { code: 'ERR_INVALID_STATE' });
+  assert.throws(() => streaming.compressedSize, { code: 'ERR_INVALID_STATE' });
+  assert.throws(() => streaming.contentIterator(), { code: 'ERR_INVALID_STATE' });
+  assert.throws(() => streaming.contentSync(), { code: 'ERR_INVALID_STATE' });
+});
+
+// Once a streaming entry has been serialized on its own (via createZipArchive,
+// not into a writable ZipFile that would promote it), its source is spent and
+// there is nothing to read back. Reads must fail with a clean state error, not
+// silently decode an empty buffer and report ERR_ZIP_ENTRY_CORRUPT.
+test('a spent (serialized-but-unpromoted) streaming entry rejects reads cleanly', async () => {
+  const entry = zlib.ZipEntry.createStream('s.txt', (async function* () { yield Buffer.from('hello'); })());
+  await drain(entry);
+  await assert.rejects(entry.content(), { code: 'ERR_INVALID_STATE' });
+  assert.throws(() => entry.contentSync(), { code: 'ERR_INVALID_STATE' });
+  assert.throws(() => entry.contentIterator(), { code: 'ERR_INVALID_STATE' });
+});
+
+test('a streaming entry can only be serialized once', async () => {
+  const entry = zlib.ZipEntry.createStream('a.bin', (async function* () { yield Buffer.from('x'); })());
+  await drain(entry);
+  await assert.rejects(drain(entry), { code: 'ERR_INVALID_STATE' });
+});
+
+test('a streaming entry rejects a non-Uint8Array chunk from its source', async () => {
+  async function* badSource() {
+    yield Buffer.alloc(0); // An empty chunk is silently skipped
+    yield 'not a buffer';
+  }
+  const entry = zlib.ZipEntry.createStream('b.bin', badSource());
+  await assert.rejects(drain(entry), { code: 'ERR_INVALID_ARG_TYPE' });
+});
+
+test('a streaming entry can use zstd compression end-to-end', async () => {
+  const payload = 'zstd stream content '.repeat(50);
+  async function* source() { yield Buffer.from(payload); }
+  const entry = zlib.ZipEntry.createStream('c.bin', source(), { method: 'zstd' });
+  const archive = await buildArchive([entry]);
+
+  const [read] = zlib.ZipEntry.read(archive);
+  assert.strictEqual(read.method, 93);
+  assert.strictEqual((await read.content()).toString(), payload);
+});
+
+test('an error from a streaming entry\'s source propagates and cleans up (deflate and zstd)', async () => {
+  for (const method of ['deflate', 'zstd']) {
+    async function* badSource() {
+      yield Buffer.from('some data before the error');
+      throw new Error(`source blew up (${method})`);
+    }
+    const entry = zlib.ZipEntry.createStream('big.bin', badSource(), { method });
+    await assert.rejects(drain(entry), { message: `source blew up (${method})` });
+  }
+});
+
+// -- contentIterator() / decodeMemberStream() error paths ------------------------
+
+test('contentIterator() enforces the same guards as content() and contentSync()', async () => {
+  // Encrypted.
+  {
+    const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('secret'), { method: 'store' });
+    const archive = await buildArchive([entry]);
+    const tampered = Buffer.from(archive);
+    tampered.writeUInt16LE(tampered.readUInt16LE(6) | 0x0001, 6);
+    const centralStart = 30 + 'f.txt'.length + 'secret'.length;
+    tampered.writeUInt16LE(tampered.readUInt16LE(centralStart + 8) | 0x0001, centralStart + 8);
+    const [read] = zlib.ZipEntry.read(tampered);
+    await assert.rejects(drain(read.contentIterator()), { code: 'ERR_ZIP_UNSUPPORTED_FEATURE' });
+  }
+  // Unsupported compression method.
+  {
+    const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('hi'), { method: 'store' });
+    const archive = await buildArchive([entry]);
+    const tampered = Buffer.from(archive);
+    tampered.writeUInt16LE(1, 8);
+    const centralStart = 30 + 'f.txt'.length + 'hi'.length;
+    tampered.writeUInt16LE(1, centralStart + 10);
+    const [read] = zlib.ZipEntry.read(tampered);
+    await assert.rejects(drain(read.contentIterator()), { code: 'ERR_ZIP_UNSUPPORTED_FEATURE' });
+  }
+  // maxSize enforced up front.
+  {
+    const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('hello world'));
+    await assert.rejects(drain(entry.contentIterator({ maxSize: 1 })), { code: 'ERR_ZIP_ENTRY_TOO_LARGE' });
+  }
+  // Declared-size mismatch.
+  {
+    const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('hello world'), { method: 'store' });
+    const archive = await buildArchive([entry]);
+    const tampered = Buffer.from(archive);
+    const centralStart = 30 + 'f.txt'.length + 'hello world'.length;
+    tampered.writeUInt32LE(1, centralStart + 24);
+    const [read] = zlib.ZipEntry.read(tampered);
+    await assert.rejects(drain(read.contentIterator()), { code: 'ERR_ZIP_ENTRY_CORRUPT' });
+  }
+  // CRC-32 mismatch, and disabling verification.
+  {
+    const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('hello world'), { method: 'store' });
+    const archive = await buildArchive([entry]);
+    const tampered = Buffer.from(archive);
+    tampered[30 + 'f.txt'.length] ^= 0xff;
+    const [read] = zlib.ZipEntry.read(tampered);
+    await assert.rejects(drain(read.contentIterator()), { code: 'ERR_ZIP_ENTRY_CORRUPT' });
+    const unverified = await drain(read.contentIterator({ verify: false }));
+    assert.strictEqual(unverified.length, 'hello world'.length);
+  }
+});
+
+// -- content()/contentSync() zstd-specific branches ----------------------------
+
+test('content() and contentSync() enforce maxSize and detect corruption for zstd entries', async () => {
+  {
+    const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('y'.repeat(5000)), { method: 'zstd' });
+    const archive = await buildArchive([entry]);
+    const [read] = zlib.ZipEntry.read(archive);
+    assert.strictEqual(read.method, 93);
+    await assert.rejects(read.content({ maxSize: 10 }), { code: 'ERR_ZIP_ENTRY_TOO_LARGE' });
+  }
+  {
+    const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('z'.repeat(200)), { method: 'zstd' });
+    const archive = await buildArchive([entry]);
+    const tampered = Buffer.from(archive);
+    const contentStart = 30 + 'f.txt'.length;
+    tampered.fill(0xff, contentStart, contentStart + 4); // Break the zstd frame itself
+    const [read] = zlib.ZipEntry.read(tampered);
+    await assert.rejects(read.content(), { code: 'ERR_ZIP_ENTRY_CORRUPT' });
+    assert.throws(() => read.contentSync(), { code: 'ERR_ZIP_ENTRY_CORRUPT' });
+  }
+});
+
+// `decodeMemberSync()` (used by `ZipEntry.prototype.contentSync()`) duplicates
+// `decodeMemberStream()`'s guards for its own, separate synchronous code
+// path; exercise them through a disk-backed ZipFile.
+test('ZipFile getSync().contentSync() enforces the same guards via decodeMemberSync()', async () => {
+  async function writeTempArchive(archive, suffix) {
+    const filePath = path.join(os.tmpdir(), `zip-coverage-contentsync-${process.pid}-${suffix}.zip`);
+    await fs.writeFile(filePath, archive);
+    return filePath;
+  }
+
+  // Encrypted.
+  {
+    const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('secret'), { method: 'store' });
+    const archive = await buildArchive([entry]);
+    const tampered = Buffer.from(archive);
+    tampered.writeUInt16LE(tampered.readUInt16LE(6) | 0x0001, 6);
+    const centralStart = 30 + 'f.txt'.length + 'secret'.length;
+    tampered.writeUInt16LE(tampered.readUInt16LE(centralStart + 8) | 0x0001, centralStart + 8);
+    const filePath = await writeTempArchive(tampered, 'encrypted');
+    const zf = zlib.ZipFile.openSync(filePath);
+    assert.throws(() => zf.getSync('f.txt').contentSync(), { code: 'ERR_ZIP_UNSUPPORTED_FEATURE' });
+    zf.closeSync();
+    await fs.unlink(filePath);
+  }
+  // maxSize, for both the deflate and the zstd decode branch.
+  for (const method of ['deflate', 'zstd']) {
+    const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('y'.repeat(5000)), { method });
+    const archive = await buildArchive([entry]);
+    const filePath = await writeTempArchive(archive, `maxsize-${method}`);
+    const zf = zlib.ZipFile.openSync(filePath);
+    assert.throws(() => zf.getSync('f.txt').contentSync({ maxSize: 10 }), { code: 'ERR_ZIP_ENTRY_TOO_LARGE' });
+    zf.closeSync();
+    await fs.unlink(filePath);
+  }
+  // A genuine decompression failure (not just a CRC mismatch after a
+  // successful decode).
+  {
+    const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('y'.repeat(500)), { method: 'deflate' });
+    const archive = await buildArchive([entry]);
+    const tampered = Buffer.from(archive);
+    const contentStart = 30 + 'f.txt'.length;
+    tampered.fill(0xff, contentStart, contentStart + 4);
+    const filePath = await writeTempArchive(tampered, 'deflate-corrupt');
+    const zf = zlib.ZipFile.openSync(filePath);
+    assert.throws(() => zf.getSync('f.txt').contentSync(), { code: 'ERR_ZIP_ENTRY_CORRUPT' });
+    zf.closeSync();
+    await fs.unlink(filePath);
+  }
+  // Declared-size mismatch ("produced N bytes, expected M").
+  {
+    const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('hello world'), { method: 'store' });
+    const archive = await buildArchive([entry]);
+    const tampered = Buffer.from(archive);
+    const centralStart = 30 + 'f.txt'.length + 'hello world'.length;
+    tampered.writeUInt32LE(1, centralStart + 24);
+    const filePath = await writeTempArchive(tampered, 'size-mismatch');
+    const zf = zlib.ZipFile.openSync(filePath);
+    assert.throws(() => zf.getSync('f.txt').contentSync(), { code: 'ERR_ZIP_ENTRY_CORRUPT' });
+    zf.closeSync();
+    await fs.unlink(filePath);
+  }
+});
+
+test('contentIterator() rejects an entry that inflates to less than its declared size', async () => {
+  const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('hi'), { method: 'store' });
+  const archive = await buildArchive([entry]);
+  const tampered = Buffer.from(archive);
+  const centralStart = 30 + 'f.txt'.length + 'hi'.length;
+  tampered.writeUInt32LE(1000, centralStart + 24); // Declared size grown beyond reality
+  const [read] = zlib.ZipEntry.read(tampered);
+  await assert.rejects(drain(read.contentIterator()), {
+    code: 'ERR_ZIP_ENTRY_CORRUPT',
+    message: /is truncated/,
+  });
+});
+
+// -- ZipBuffer / ZipFile iteration protocols -----------------------------------
+
+test('ZipBuffer exposes Map-like forEach/values/entries/iteration/toStringTag', async () => {
+  const archive = await buildArchive([
+    await zlib.ZipEntry.create('a.txt', Buffer.from('1')),
+    await zlib.ZipEntry.create('b.txt', Buffer.from('2')),
+  ]);
+  const zip = new zlib.ZipBuffer(archive);
+
+  const seen = [];
+  zip.forEach((entry, key, self) => {
+    seen.push(key);
+    assert.strictEqual(self, zip);
+    assert.strictEqual(entry.name, key);
+  });
+  assert.deepStrictEqual(seen.sort(), ['a.txt', 'b.txt']);
+
+  assert.deepStrictEqual([...zip.values()].map((e) => e.name).sort(), ['a.txt', 'b.txt']);
+  assert.deepStrictEqual([...zip.entries()].map(([k]) => k).sort(), ['a.txt', 'b.txt']);
+  assert.deepStrictEqual([...zip].map(([k]) => k).sort(), ['a.txt', 'b.txt']);
+  assert.strictEqual(Object.prototype.toString.call(zip), '[object ZipBuffer]');
+  assert.throws(() => zip.addEntry({}), { code: 'ERR_INVALID_ARG_TYPE' });
+});
+
+test('ZipFile exposes the same iteration protocol, plus its Sync counterparts', async () => {
+  const archive = await buildArchive([
+    await zlib.ZipEntry.create('a.txt', Buffer.from('1')),
+    await zlib.ZipEntry.create('b.txt', Buffer.from('2')),
+  ]);
+  const filePath = path.join(os.tmpdir(), `zip-coverage-iteration-${process.pid}.zip`);
+  await fs.writeFile(filePath, archive);
+
+  const zf = await zlib.ZipFile.open(filePath);
+  try {
+    const pending = [];
+    zf.forEach((valuePromise) => pending.push(valuePromise));
+    await Promise.all(pending); // Let every dangling get() settle before closing
+
+    zf.forEachSync(() => {});
+    assert.deepStrictEqual([...zf.valuesSync()].map((e) => e.name).sort(), ['a.txt', 'b.txt']);
+    assert.deepStrictEqual([...zf.entriesSync()].map(([k]) => k).sort(), ['a.txt', 'b.txt']);
+    assert.deepStrictEqual([...zf.keys()].sort(), ['a.txt', 'b.txt']);
+    assert.strictEqual(zf.size, 2);
+    assert.strictEqual(Object.prototype.toString.call(zf), '[object ZipFile]');
+
+    const names = [];
+    for await (const entry of zf) names.push(entry.name);
+    assert.deepStrictEqual(names.sort(), ['a.txt', 'b.txt']);
+
+    // Synchronous iteration (Symbol.iterator) yields [name, Promise<ZipEntry>].
+    const syncPairs = [...zf];
+    assert.deepStrictEqual(syncPairs.map(([k]) => k).sort(), ['a.txt', 'b.txt']);
+    const resolved = await Promise.all(syncPairs.map(([, v]) => v));
+    assert.deepStrictEqual(resolved.map((e) => e.name).sort(), ['a.txt', 'b.txt']);
+  } finally {
+    await zf[Symbol.asyncDispose]();
+  }
+
+  const writable = await zlib.ZipFile.open(filePath, { writable: true });
+  await assert.rejects(writable.addEntry({}), { code: 'ERR_INVALID_ARG_TYPE' });
+  assert.throws(() => writable.addEntrySync({}), { code: 'ERR_INVALID_ARG_TYPE' });
+  await writable.close();
+
+  const zf2 = zlib.ZipFile.openSync(filePath);
+  zf2[Symbol.dispose]();
+
+  await fs.unlink(filePath);
+});
+
+// -- ZipFile (on-disk) error paths ---------------------------------------------
+
+test('ZipFile.open()/openSync() reject a file with no end-of-central-directory record', async () => {
+  const filePath = path.join(os.tmpdir(), `zip-coverage-garbage-${process.pid}.zip`);
+  await fs.writeFile(filePath, Buffer.from('not a zip file, just garbage bytes'));
+  try {
+    await assert.rejects(zlib.ZipFile.open(filePath), { code: 'ERR_ZIP_INVALID_ARCHIVE' });
+    assert.throws(() => zlib.ZipFile.openSync(filePath), { code: 'ERR_ZIP_INVALID_ARCHIVE' });
+  } finally {
+    await fs.unlink(filePath);
+  }
+});
+
+test('ZipFile get()/getSync()/stream() reject a missing entry name', async () => {
+  const archive = await buildArchive([await zlib.ZipEntry.create('a.txt', Buffer.from('x'))]);
+  const filePath = path.join(os.tmpdir(), `zip-coverage-notfound-${process.pid}.zip`);
+  await fs.writeFile(filePath, archive);
+  const zf = await zlib.ZipFile.open(filePath);
+  try {
+    await assert.rejects(zf.get('missing'), { code: 'ERR_ZIP_ENTRY_NOT_FOUND' });
+    assert.throws(() => zf.getSync('missing'), { code: 'ERR_ZIP_ENTRY_NOT_FOUND' });
+    await assert.rejects(zf.stream('missing'), { code: 'ERR_ZIP_ENTRY_NOT_FOUND' });
+  } finally {
+    await zf.close();
+    await fs.unlink(filePath);
+  }
+});
+
+test('a corrupted local file header offset is rejected when the entry is read', async () => {
+  const name = 'a.txt';
+  const content = Buffer.from('hello');
+  const archive = await buildArchive([await zlib.ZipEntry.create(name, content, { method: 'store' })]);
+  const centralHeaderStart = 30 + name.length + content.length;
+  const tampered = Buffer.from(archive);
+  // Point the local file header offset at the central directory itself
+  // (signature 0x02014b50, not the local-header signature 0x04034b50).
+  tampered.writeUInt32LE(centralHeaderStart, centralHeaderStart + 42);
+  const filePath = path.join(os.tmpdir(), `zip-coverage-badlocal-${process.pid}.zip`);
+  await fs.writeFile(filePath, tampered);
+
+  const zf = await zlib.ZipFile.open(filePath);
+  const zfSync = zlib.ZipFile.openSync(filePath);
+  try {
+    // get() is lazy; the corrupt header is only seen when the entry is read.
+    await assert.rejects((await zf.get(name)).content(), { code: 'ERR_ZIP_INVALID_ARCHIVE' });
+    assert.throws(() => zfSync.getSync(name).contentSync(), { code: 'ERR_ZIP_INVALID_ARCHIVE' });
+  } finally {
+    await zf.close();
+    zfSync.closeSync();
+    await fs.unlink(filePath);
+  }
+});
+
+test('a declared compressed size reaching past the end of the file is rejected', async () => {
+  const name = 'a.txt';
+  const content = Buffer.from('hello');
+  const archive = await buildArchive([await zlib.ZipEntry.create(name, content, { method: 'store' })]);
+  const centralHeaderStart = 30 + name.length + content.length;
+  const tampered = Buffer.from(archive);
+  tampered.writeUInt32LE(archive.length * 10, centralHeaderStart + 20); // compressedSize
+  const filePath = path.join(os.tmpdir(), `zip-coverage-eof-${process.pid}.zip`);
+  await fs.writeFile(filePath, tampered);
+
+  const zf = await zlib.ZipFile.open(filePath);
+  const zfSync = zlib.ZipFile.openSync(filePath);
+  try {
+    // get() is lazy; the truncated read is only hit when the entry is read.
+    await assert.rejects((await zf.get(name)).content(), { code: 'ERR_ZIP_INVALID_ARCHIVE' });
+    assert.throws(() => zfSync.getSync(name).contentSync(), { code: 'ERR_ZIP_INVALID_ARCHIVE' });
+  } finally {
+    await zf.close();
+    zfSync.closeSync();
+    await fs.unlink(filePath);
+  }
+});
+
+test('content()/contentSync() refuse to buffer an entry declaring more than kMaxLength bytes', async () => {
+  const name = 'f.txt';
+  const content = Buffer.from('hello');
+  const archive = await buildArchive([await zlib.ZipEntry.create(name, content, { method: 'store' })]);
+
+  // A Zip64-declared compressedSize equal to kMaxLength is the largest value
+  // that still parses (readSafeUint64 caps at the safe-integer ceiling, which
+  // is kMaxLength on 64-bit) yet is too large to hold in a single buffer.
+  // get()/getSync() are lazy and never read here; the refusal happens when the
+  // buffering read paths try to allocate - no multi-GB file is needed, since
+  // the check runs before any read.
+  const centralHeaderStart = 30 + name.length + content.length;
+  const nameStart = centralHeaderStart + 46;
+  const tlv = Buffer.allocUnsafe(4 + 8);
+  tlv.writeUInt16LE(0x0001, 0);
+  tlv.writeUInt16LE(8, 2);
+  tlv.writeBigUInt64LE(BigInt(require('node:buffer').kMaxLength), 4);
+  const before = archive.subarray(0, nameStart + name.length);
+  const after = archive.subarray(nameStart + name.length);
+  const patched = Buffer.concat([before, tlv, after]);
+  patched.writeUInt16LE(tlv.length, centralHeaderStart + 30);
+  patched.writeUInt32LE(0xffffffff, centralHeaderStart + 20); // compressedSize sentinel
+  const eocdOffset = patched.length - 22;
+  patched.writeUInt32LE(patched.readUInt32LE(eocdOffset + 12) + tlv.length, eocdOffset + 12);
+
+  const toolargeFilePath = path.join(os.tmpdir(), `zip-coverage-toolarge-${process.pid}.zip`);
+  await fs.writeFile(toolargeFilePath, patched);
+  const zf2 = await zlib.ZipFile.open(toolargeFilePath);
+  const zf2Sync = zlib.ZipFile.openSync(toolargeFilePath);
+  try {
+    // get()/getSync() are lazy, so they resolve without touching the member.
+    const entry = await zf2.get(name);
+    await assert.rejects(entry.content(),
+                         { code: 'ERR_ZIP_ENTRY_TOO_LARGE', message: /use contentIterator\(\) instead/ });
+    assert.throws(() => zf2Sync.getSync(name).contentSync(),
+                  { code: 'ERR_ZIP_ENTRY_TOO_LARGE', message: /use contentIterator\(\) instead/ });
+  } finally {
+    await zf2.close();
+    zf2Sync.closeSync();
+    await fs.unlink(toolargeFilePath);
+  }
+});
+
+// -- forcing Zip64 structures without a multi-gigabyte archive -----------------
+
+test('createZipArchiveSync() also switches to Zip64 structures at 0xFFFF entries', () => {
+  const ZIP64_EOCD_SIGNATURE = Buffer.from([0x50, 0x4b, 0x06, 0x06]);
+  const entries = [];
+  for (let i = 0; i < 0x10000; i++) {
+    entries.push(zlib.ZipEntry.createSync(`entry-${i}`, Buffer.alloc(0), { method: 'store' }));
+  }
+  const chunks = [];
+  for (const chunk of zlib.createZipArchiveSync(entries)) chunks.push(chunk);
+  const archive = Buffer.concat(chunks);
+  assert.ok(archive.includes(ZIP64_EOCD_SIGNATURE));
+  assert.strictEqual([...zlib.ZipEntry.read(archive)].length, 0x10000);
+}, { timeout: 120_000 });
+
+// -- createZipArchive()'s single options argument, baseOffset, and Readable return --
+
+const CENTRAL_FILE_HEADER_SIGNATURE = Buffer.from([0x50, 0x4b, 0x01, 0x02]);
+
+test('createZipArchive() returns a pipeable, async-iterable, non-object-mode Readable', async () => {
+  const { Readable } = require('node:stream');
+  const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('hi'));
+  const stream = zlib.createZipArchive([entry]);
+  assert.ok(stream instanceof Readable);
+  assert.strictEqual(stream.readableObjectMode, false);
+  const chunks = [];
+  for await (const chunk of stream) chunks.push(chunk);
+  assert.strictEqual([...zlib.ZipEntry.read(Buffer.concat(chunks))][0].name, 'f.txt');
+});
+
+test('createZipArchive()/createZipArchiveSync() take a plain string as comment shorthand', async () => {
+  const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('hi'));
+  const zip = new zlib.ZipBuffer(await drain(zlib.createZipArchive([entry], 'hello')));
+  assert.strictEqual(zip.comment, 'hello');
+
+  const entrySync = zlib.ZipEntry.createSync('f.txt', Buffer.from('hi'));
+  const chunks = [...zlib.createZipArchiveSync([entrySync], 'hello-sync')];
+  const zipSync = new zlib.ZipBuffer(Buffer.concat(chunks));
+  assert.strictEqual(zipSync.comment, 'hello-sync');
+});
+
+test('createZipArchive()/createZipArchiveSync() take an { comment, baseOffset } options object', async () => {
+  const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('hi'));
+  const zip = new zlib.ZipBuffer(await drain(zlib.createZipArchive([entry], { comment: 'hi there' })));
+  assert.strictEqual(zip.comment, 'hi there');
+});
+
+test('createZipArchive()/createZipArchiveSync() reject a non-string, non-object options argument', async () => {
+  await assert.rejects(drain(zlib.createZipArchive([], 123)), { code: 'ERR_INVALID_ARG_TYPE' });
+  assert.throws(() => [...zlib.createZipArchiveSync([], 123)], { code: 'ERR_INVALID_ARG_TYPE' });
+  await assert.rejects(drain(zlib.createZipArchive([], null)), { code: 'ERR_INVALID_ARG_TYPE' });
+});
+
+test('createZipArchive()/createZipArchiveSync() validate options.baseOffset', async () => {
+  await assert.rejects(drain(zlib.createZipArchive([], { baseOffset: -1 })), { code: 'ERR_OUT_OF_RANGE' });
+  await assert.rejects(drain(zlib.createZipArchive([], { baseOffset: 1.5 })), { code: 'ERR_OUT_OF_RANGE' });
+  assert.throws(() => [...zlib.createZipArchiveSync([], { baseOffset: -1 })], { code: 'ERR_OUT_OF_RANGE' });
+});
+
+test('options.baseOffset shifts every recorded offset, so a prefixed archive is ' +
+     'self-describing without relying on prefix auto-detection', async () => {
+  const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('hello offset'));
+  const prefix = Buffer.from('#!/bin/sh\nexit 0\n');
+
+  const shifted = await drain(zlib.createZipArchive([entry], { baseOffset: prefix.byteLength }));
+  const shiftedCentral = shifted.indexOf(CENTRAL_FILE_HEADER_SIGNATURE);
+  assert.strictEqual(shifted.readUInt32LE(shiftedCentral + 42), prefix.byteLength);
+
+  const entryUnshifted = await zlib.ZipEntry.create('f.txt', Buffer.from('hello offset'));
+  const unshifted = await drain(zlib.createZipArchive([entryUnshifted]));
+  const unshiftedCentral = unshifted.indexOf(CENTRAL_FILE_HEADER_SIGNATURE);
+  assert.strictEqual(unshifted.readUInt32LE(unshiftedCentral + 42), 0);
+
+  const combined = Buffer.concat([prefix, shifted]);
+  const zip = new zlib.ZipBuffer(combined);
+  assert.strictEqual((await zip.get('f.txt').content()).toString(), 'hello offset');
+});
+
+test('zipBuffer.toBuffer()/toBufferSync() forward the same string/options-object shorthand', async () => {
+  const zip = new zlib.ZipBuffer(await drain(zlib.createZipArchive([])));
+  await zip.add('f.txt', Buffer.from('hi'));
+
+  assert.strictEqual(new zlib.ZipBuffer(await zip.toBuffer('a comment')).comment, 'a comment');
+  assert.strictEqual(new zlib.ZipBuffer(await zip.toBuffer({ comment: 'an object comment' })).comment,
+                     'an object comment');
+  assert.strictEqual(new zlib.ZipBuffer(zip.toBufferSync('sync comment')).comment, 'sync comment');
+
+  const prefix = Buffer.from('junk\n');
+  const shifted = await zip.toBuffer({ baseOffset: prefix.byteLength });
+  const shiftedCentral = shifted.indexOf(CENTRAL_FILE_HEADER_SIGNATURE);
+  assert.strictEqual(shifted.readUInt32LE(shiftedCentral + 42), prefix.byteLength);
+});

--- a/test/parallel/test-zlib-zip-fuzz.js
+++ b/test/parallel/test-zlib-zip-fuzz.js
@@ -1,0 +1,85 @@
+'use strict';
+
+require('../common');
+
+const assert = require('node:assert');
+const zlib = require('node:zlib');
+const { test } = require('node:test');
+
+function mulberry32(seed) {
+  let state = seed >>> 0;
+  return function() {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+async function buildSeedArchive() {
+  const entries = [
+    await zlib.ZipEntry.create('hello.txt', Buffer.from('Hello, world!'.repeat(30))),
+    await zlib.ZipEntry.create('raw.bin', Buffer.from([1, 2, 3, 4, 5]), { method: 'store' }),
+    await zlib.ZipEntry.create('empty/', Buffer.alloc(0)),
+  ];
+  const chunks = [];
+  for await (const chunk of zlib.createZipArchive(entries, 'seed archive')) chunks.push(chunk);
+  return Buffer.concat(chunks);
+}
+
+function mutate(random, seed) {
+  const buf = Buffer.from(seed);
+  const kind = Math.floor(random() * 4);
+  if (kind === 0) {
+    // Flip a handful of random bits.
+    const flips = 1 + Math.floor(random() * 8);
+    for (let i = 0; i < flips; i++) {
+      buf[Math.floor(random() * buf.length)] ^= 1 << Math.floor(random() * 8);
+    }
+  } else if (kind === 1) {
+    // Overwrite a random window with boundary-ish values.
+    const boundary = [0x00, 0xff, 0x50, 0x4b][Math.floor(random() * 4)];
+    const start = Math.floor(random() * buf.length);
+    const len = Math.min(buf.length - start, 1 + Math.floor(random() * 8));
+    buf.fill(boundary, start, start + len);
+  } else if (kind === 2) {
+    // Truncate.
+    return buf.subarray(0, Math.floor(random() * buf.length));
+  } else {
+    // Extend with random padding.
+    const pad = Buffer.allocUnsafe(1 + Math.floor(random() * 16));
+    for (let i = 0; i < pad.length; i++) pad[i] = Math.floor(random() * 256);
+    return Buffer.concat([buf, pad]);
+  }
+  return buf;
+}
+
+test('the parser only ever throws Error on mutated archives, never crashes or hangs', async () => {
+  const seed = await buildSeedArchive();
+  const random = mulberry32(0x5EED1234);
+  const iterations = 3000;
+
+  for (let i = 0; i < iterations; i++) {
+    const candidate = mutate(random, seed);
+    try {
+      const entries = [...zlib.ZipEntry.read(candidate)];
+      for (const entry of entries) {
+        try {
+          await entry.content();
+        } catch (err) {
+          assert.ok(err instanceof Error, `content() threw non-Error: ${err}`);
+        }
+      }
+    } catch (err) {
+      assert.ok(err instanceof Error, `read() threw non-Error: ${err}`);
+    }
+
+    try {
+      using zipBuffer = new zlib.ZipBuffer(candidate);
+      assert.ok(zipBuffer.size >= 0);
+    } catch (err) {
+      assert.ok(err instanceof Error, `ZipBuffer threw non-Error: ${err}`);
+    }
+  }
+}, { timeout: 60_000 });

--- a/test/parallel/test-zlib-zip-hardening.js
+++ b/test/parallel/test-zlib-zip-hardening.js
@@ -1,0 +1,194 @@
+'use strict';
+
+require('../common');
+
+const assert = require('node:assert');
+const zlib = require('node:zlib');
+const { test } = require('node:test');
+
+async function buildArchive(entries, comment) {
+  const chunks = [];
+  for await (const chunk of zlib.createZipArchive(entries, comment)) chunks.push(chunk);
+  return Buffer.concat(chunks);
+}
+
+function buildEocd({ diskNumber = 0, cdDiskNumber = 0, cdDiskRecords = 0,
+                     totalRecords = 0, cdSize = 0, cdOffset = 0, comment = Buffer.alloc(0) } = {}) {
+  const buf = Buffer.allocUnsafe(22 + comment.length);
+  buf.writeUInt32LE(0x06054b50, 0);
+  buf.writeUInt16LE(diskNumber, 4);
+  buf.writeUInt16LE(cdDiskNumber, 6);
+  buf.writeUInt16LE(cdDiskRecords, 8);
+  buf.writeUInt16LE(totalRecords, 10);
+  buf.writeUInt32LE(cdSize, 12);
+  buf.writeUInt32LE(cdOffset, 16);
+  buf.writeUInt16LE(comment.length, 20);
+  comment.copy(buf, 22);
+  return buf;
+}
+
+test('an empty or tiny buffer is rejected as an invalid archive', () => {
+  for (const buf of [Buffer.alloc(0), Buffer.alloc(10), Buffer.from('not a zip')]) {
+    assert.throws(() => [...zlib.ZipEntry.read(buf)], { code: 'ERR_ZIP_INVALID_ARCHIVE' });
+  }
+});
+
+test('garbage or truncated data is rejected', () => {
+  const garbage = Buffer.alloc(100, 0x41);
+  assert.throws(() => [...zlib.ZipEntry.read(garbage)], { code: 'ERR_ZIP_INVALID_ARCHIVE' });
+
+  const truncated = buildEocd({ totalRecords: 5, cdSize: 46 * 5 }).subarray(0, 10);
+  assert.throws(() => [...zlib.ZipEntry.read(truncated)], { code: 'ERR_ZIP_INVALID_ARCHIVE' });
+});
+
+test('an EOCD-looking signature inside a trailing comment is not mistaken for the real one', async () => {
+  const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('hi'), { method: 'store' });
+  // The comment scan walks backward through the trailing comment bytes
+  // before it reaches the genuine EOCD signature; embedding 4 bytes that
+  // look like one partway through must not be mistaken for the real record.
+  const fakeSignature = String.fromCharCode(0x50, 0x4b, 0x05, 0x06);
+  const archive = await buildArchive([entry], `before ${fakeSignature} after`);
+
+  const read = [...zlib.ZipEntry.read(archive)];
+  assert.strictEqual(read.length, 1);
+  assert.strictEqual(read[0].name, 'f.txt');
+});
+
+test('a declared-size mismatch is rejected as corrupt', async () => {
+  const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('hello world'), { method: 'store' });
+  const archive = await buildArchive([entry]);
+
+  // Shrink the *declared* uncompressed size in the central directory record
+  // without touching the stored bytes themselves, so the amount of data
+  // produced no longer matches what the header promised.
+  const tampered = Buffer.from(archive);
+  const centralHeaderStart = 30 + 'f.txt'.length + 'hello world'.length;
+  const uncompressedSizeOffset = centralHeaderStart + 24;
+  tampered.writeUInt32LE(1, uncompressedSizeOffset);
+
+  const [tamperedEntry] = zlib.ZipEntry.read(tampered);
+  assert.strictEqual(tamperedEntry.size, 1);
+  await assert.rejects(tamperedEntry.content(), { code: 'ERR_ZIP_ENTRY_CORRUPT' });
+});
+
+test('CRC-32 verification catches a single flipped byte, and can be disabled', async () => {
+  const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('hello world'), { method: 'store' });
+  const archive = await buildArchive([entry]);
+  const tampered = Buffer.from(archive);
+  const contentStart = 30 + 'f.txt'.length;
+  tampered[contentStart] ^= 0xff;
+
+  const [tamperedEntry] = zlib.ZipEntry.read(tampered);
+  await assert.rejects(tamperedEntry.content(), { code: 'ERR_ZIP_ENTRY_CORRUPT' });
+  const unverified = await tamperedEntry.content({ verify: false });
+  assert.strictEqual(unverified.length, 'hello world'.length);
+});
+
+test('content() enforces maxSize before allocating', async () => {
+  const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('hello world'));
+  await assert.rejects(entry.content({ maxSize: 1 }), { code: 'ERR_ZIP_ENTRY_TOO_LARGE' });
+});
+
+test('a forged small header whose content inflates past maxSize is rejected', async () => {
+  // The up-front maxSize check trusts the declared size, so a bomb forges a
+  // tiny declared size to clear it; the decompressor's maxOutputLength backstop
+  // must still catch the content actually inflating past the limit.
+  for (const { method, re } of [
+    { method: 'deflate', re: /inflates beyond/ },
+    { method: 'zstd', re: /decompresses beyond/ },
+  ]) {
+    const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('x'.repeat(5000)), { method });
+    const archive = await buildArchive([entry]);
+    const tampered = Buffer.from(archive);
+    const eocd = tampered.length - 22; // No comment, so EOCD is the last 22 bytes
+    const cdOffset = tampered.readUInt32LE(eocd + 16);
+    tampered.writeUInt32LE(50, cdOffset + 24); // Forge declared uncompressedSize
+
+    const [e] = zlib.ZipEntry.read(tampered);
+    assert.strictEqual(e.size, 50); // 50 <= maxSize 100 clears the up-front check
+    await assert.rejects(e.content({ maxSize: 100 }), { code: 'ERR_ZIP_ENTRY_TOO_LARGE', message: re });
+    assert.throws(() => e.contentSync({ maxSize: 100 }), { code: 'ERR_ZIP_ENTRY_TOO_LARGE', message: re });
+  }
+});
+
+test('getMaxZipContentSize()/setMaxZipContentSize() control the default guard', async () => {
+  const original = zlib.getMaxZipContentSize();
+  try {
+    zlib.setMaxZipContentSize(1);
+    const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('hello world'));
+    await assert.rejects(entry.content(), { code: 'ERR_ZIP_ENTRY_TOO_LARGE' });
+  } finally {
+    zlib.setMaxZipContentSize(original);
+  }
+  assert.strictEqual(zlib.getMaxZipContentSize(), original);
+});
+
+test('streaming a partially-consumed entry does not hang or leak', async () => {
+  async function* source() {
+    for (let i = 0; i < 1000; i++) {
+      yield Buffer.alloc(1024, i & 0xff);
+    }
+  }
+  const entry = zlib.ZipEntry.createStream('big.bin', source());
+  let count = 0;
+  let bytesSeen = 0;
+  for await (const chunk of entry) {
+    count++;
+    bytesSeen += chunk.length;
+    if (count > 2) break;
+  }
+  assert.ok(count > 2);
+  assert.ok(bytesSeen > 0);
+});
+
+test('an overlong file name is rejected', async () => {
+  await assert.rejects(
+    zlib.ZipEntry.create('x'.repeat(70000), Buffer.alloc(0)),
+    { code: 'ERR_ZIP_ENTRY_TOO_LARGE' },
+  );
+});
+
+test('an empty file name is rejected', async () => {
+  await assert.rejects(
+    zlib.ZipEntry.create('', Buffer.alloc(0)),
+    { code: 'ERR_INVALID_ARG_VALUE' },
+  );
+});
+
+test('a multi-disk archive is rejected', () => {
+  const eocd = buildEocd({ diskNumber: 1, cdDiskNumber: 1 });
+  assert.throws(() => [...zlib.ZipEntry.read(eocd)], { code: 'ERR_ZIP_UNSUPPORTED_FEATURE' });
+});
+
+test('an encrypted entry is rejected', async () => {
+  const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('secret'), { method: 'store' });
+  const archive = await buildArchive([entry]);
+  // Set the encrypted bit (bit 0) in both the local and central header flags.
+  const tampered = Buffer.from(archive);
+  const localFlagsOffset = 6;
+  tampered.writeUInt16LE(tampered.readUInt16LE(localFlagsOffset) | 0x0001, localFlagsOffset);
+  const centralHeaderStart = 30 + 'f.txt'.length + 'secret'.length;
+  const centralFlagsOffset = centralHeaderStart + 8;
+  tampered.writeUInt16LE(tampered.readUInt16LE(centralFlagsOffset) | 0x0001, centralFlagsOffset);
+
+  const [tamperedEntry] = zlib.ZipEntry.read(tampered);
+  await assert.rejects(tamperedEntry.content(), { code: 'ERR_ZIP_UNSUPPORTED_FEATURE' });
+});
+
+test('an entry using an unsupported compression method is rejected', async () => {
+  const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('hi'), { method: 'store' });
+  const archive = await buildArchive([entry]);
+  // Set the method to 1 (Shrunk), which this implementation does not support,
+  // in both the local and central headers.
+  const tampered = Buffer.from(archive);
+  const localMethodOffset = 8;
+  tampered.writeUInt16LE(1, localMethodOffset);
+  const centralHeaderStart = 30 + 'f.txt'.length + 'hi'.length;
+  const centralMethodOffset = centralHeaderStart + 10;
+  tampered.writeUInt16LE(1, centralMethodOffset);
+
+  const [tamperedEntry] = zlib.ZipEntry.read(tampered);
+  assert.strictEqual(tamperedEntry.method, 1);
+  await assert.rejects(tamperedEntry.content(), { code: 'ERR_ZIP_UNSUPPORTED_FEATURE' });
+  assert.throws(() => tamperedEntry.contentSync(), { code: 'ERR_ZIP_UNSUPPORTED_FEATURE' });
+});

--- a/test/parallel/test-zlib-zip-interop.js
+++ b/test/parallel/test-zlib-zip-interop.js
@@ -1,0 +1,118 @@
+'use strict';
+
+require('../common');
+const assert = require('node:assert');
+const zlib = require('node:zlib');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const os = require('node:os');
+const { spawnSync } = require('node:child_process');
+const { test } = require('node:test');
+
+function hasTool(command, args = ['--help']) {
+  try {
+    const result = spawnSync(command, args, { stdio: 'ignore' });
+    return result.error === undefined;
+  } catch {
+    return false;
+  }
+}
+
+// unzip/zipinfo/bsdtar decide how to render a UTF-8 entry name (per the
+// general-purpose bit 11 flag we set) by converting it to the process
+// locale; under the "C"/"POSIX" locale that conversion fails or mangles
+// non-ASCII bytes, independent of whether the archive itself is well-formed.
+// CI runners don't all default to a UTF-8 locale, so pick one that's
+// actually installed rather than trusting the ambient environment.
+function findUtf8Locale() {
+  const result = spawnSync('locale', ['-a'], { encoding: 'utf8' });
+  if (result.status !== 0 || !result.stdout) return null;
+  const locales = result.stdout.split('\n').map((line) => line.trim());
+  const preferred = ['C.UTF-8', 'C.utf8', 'en_US.UTF-8', 'en_US.utf8'];
+  for (const name of preferred) {
+    if (locales.includes(name)) return name;
+  }
+  return locales.find((name) => /utf-?8$/i.test(name)) || null;
+}
+
+test('an archive written by createZipArchive is readable by unzip, zipinfo, and bsdtar', async (t) => {
+  if (!hasTool('unzip', ['-v']) || !hasTool('zipinfo', ['-v']) || !hasTool('bsdtar', ['--version'])) {
+    t.skip('unzip, zipinfo, or bsdtar is not available');
+    return;
+  }
+  const locale = findUtf8Locale();
+  if (!locale) {
+    t.skip('no UTF-8 locale is available to render non-ASCII entry names');
+    return;
+  }
+  const env = { ...process.env, LANG: locale, LC_ALL: locale };
+
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'zlib-zip-interop-'));
+  try {
+    const files = {
+      'hello.txt': Buffer.from('Hello, world!'.repeat(50)),
+      'raw.bin': Buffer.from([1, 2, 3, 4, 5]),
+      'unicode-名前.txt': Buffer.from('unicode name'),
+    };
+    const entries = [];
+    for (const [name, data] of Object.entries(files)) {
+      entries.push(await zlib.ZipEntry.create(name, data));
+    }
+    const chunks = [];
+    for await (const chunk of zlib.createZipArchive(entries)) chunks.push(chunk);
+    const archivePath = path.join(dir, 'archive.zip');
+    await fs.writeFile(archivePath, Buffer.concat(chunks));
+
+    const unzipTest = spawnSync('unzip', ['-t', archivePath], { env });
+    assert.strictEqual(unzipTest.status, 0, unzipTest.stderr?.toString());
+
+    const zipinfo = spawnSync('zipinfo', [archivePath], { env });
+    assert.strictEqual(zipinfo.status, 0);
+    for (const name of Object.keys(files)) {
+      assert.ok(zipinfo.stdout.toString().includes(name), `zipinfo missing ${name}`);
+    }
+
+    const extractDir = path.join(dir, 'out');
+    await fs.mkdir(extractDir);
+    const bsdtar = spawnSync('bsdtar', ['-xf', archivePath, '-C', extractDir], { env });
+    assert.strictEqual(bsdtar.status, 0, bsdtar.stderr?.toString());
+    for (const [name, data] of Object.entries(files)) {
+      const extracted = await fs.readFile(path.join(extractDir, name));
+      assert.deepStrictEqual(extracted, data);
+    }
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('an archive written by Python\'s zipfile module is readable by ZipFile', async (t) => {
+  if (!hasTool('python3', ['--version'])) {
+    t.skip('python3 is not available');
+    return;
+  }
+
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'zlib-zip-interop-'));
+  try {
+    const archivePath = path.join(dir, 'python.zip');
+    const script = `
+import zipfile
+with zipfile.ZipFile(${JSON.stringify(archivePath)}, 'w') as z:
+    z.writestr('a.txt', 'hello from python')
+    z.writestr('b.bin', bytes(range(256)))
+`;
+    const result = spawnSync('python3', ['-c', script]);
+    assert.strictEqual(result.status, 0, result.stderr?.toString());
+
+    const zip = await zlib.ZipFile.open(archivePath);
+    try {
+      const a = await zip.get('a.txt');
+      assert.strictEqual((await a.content()).toString(), 'hello from python');
+      const b = await zip.get('b.bin');
+      assert.deepStrictEqual(await b.content(), Buffer.from(Array.from({ length: 256 }, (_, i) => i)));
+    } finally {
+      await zip.close();
+    }
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});

--- a/test/parallel/test-zlib-zip-metadata.js
+++ b/test/parallel/test-zlib-zip-metadata.js
@@ -1,0 +1,81 @@
+'use strict';
+
+require('../common');
+
+const assert = require('node:assert');
+const zlib = require('node:zlib');
+const { test } = require('node:test');
+
+async function roundTrip(options) {
+  const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('x'), options);
+  const chunks = [];
+  for await (const chunk of zlib.createZipArchive([entry])) chunks.push(chunk);
+  const archive = Buffer.concat(chunks);
+  return [...zlib.ZipEntry.read(archive)][0];
+}
+
+test('modification time round-trips at 2-second resolution', async () => {
+  const modified = new Date(2024, 5, 15, 13, 45, 30);
+  const read = await roundTrip({ modified });
+  assert.strictEqual(read.modified.getFullYear(), 2024);
+  assert.strictEqual(read.modified.getMonth(), 5);
+  assert.strictEqual(read.modified.getDate(), 15);
+  assert.strictEqual(read.modified.getHours(), 13);
+  assert.strictEqual(read.modified.getMinutes(), 45);
+  assert.strictEqual(read.modified.getSeconds(), 30);
+});
+
+test('a date before 1980 is clamped to the DOS epoch', async () => {
+  const read = await roundTrip({ modified: new Date(1970, 0, 1) });
+  assert.strictEqual(read.modified.getFullYear(), 1980);
+  assert.strictEqual(read.modified.getMonth(), 0);
+  assert.strictEqual(read.modified.getDate(), 1);
+});
+
+test('a date after 2107 is clamped to the DOS ceiling', async () => {
+  const read = await roundTrip({ modified: new Date(2200, 0, 1) });
+  assert.strictEqual(read.modified.getFullYear(), 2107);
+  assert.strictEqual(read.modified.getMonth(), 11);
+  assert.strictEqual(read.modified.getDate(), 31);
+});
+
+test('Unix mode round-trips for files and directories', async () => {
+  const file = await roundTrip({ mode: 0o600 });
+  assert.strictEqual(file.mode, 0o600);
+
+  const dirEntry = await zlib.ZipEntry.create('dir/', Buffer.alloc(0), { mode: 0o700 });
+  const chunks = [];
+  for await (const chunk of zlib.createZipArchive([dirEntry])) chunks.push(chunk);
+  const read = [...zlib.ZipEntry.read(Buffer.concat(chunks))][0];
+  assert.strictEqual(read.mode, 0o700);
+  assert.strictEqual(read.isDirectory, true);
+});
+
+test('default modes are applied when none is given', async () => {
+  const file = await roundTrip({});
+  assert.strictEqual(file.mode, 0o644);
+
+  const dirEntry = await zlib.ZipEntry.create('dir/', Buffer.alloc(0));
+  const chunks = [];
+  for await (const chunk of zlib.createZipArchive([dirEntry])) chunks.push(chunk);
+  const read = [...zlib.ZipEntry.read(Buffer.concat(chunks))][0];
+  assert.strictEqual(read.mode, 0o755);
+});
+
+test('an entry comment round-trips', async () => {
+  const read = await roundTrip({ comment: 'a comment' });
+  assert.strictEqual(read.comment, 'a comment');
+});
+
+test('zipEntry.compressed is true only for the deflate method', async () => {
+  const big = Buffer.from('x'.repeat(1000)); // Compressible, so deflate/zstd win
+  const deflated = await zlib.ZipEntry.create('d.txt', big, { method: 'deflate' });
+  const stored = await zlib.ZipEntry.create('s.bin', Buffer.from([1, 2, 3]), { method: 'store' });
+  const zstd = await zlib.ZipEntry.create('z.txt', big, { method: 'zstd' });
+  assert.strictEqual(deflated.compressed, true);
+  assert.strictEqual(stored.compressed, false);
+  assert.strictEqual(zstd.compressed, false); // Deflate-specific: method === 8
+
+  // Survives a read-back round-trip too.
+  assert.strictEqual((await roundTrip({ method: 'store' })).compressed, false);
+});

--- a/test/parallel/test-zlib-zip-property.js
+++ b/test/parallel/test-zlib-zip-property.js
@@ -1,0 +1,128 @@
+'use strict';
+
+require('../common');
+
+const assert = require('node:assert');
+const zlib = require('node:zlib');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const os = require('node:os');
+const { test } = require('node:test');
+
+// A small, seeded PRNG so failures are reproducible without pulling in a
+// dependency.
+function mulberry32(seed) {
+  let state = seed >>> 0;
+  return function() {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function randomBuffer(random, length) {
+  const buf = Buffer.allocUnsafe(length);
+  for (let i = 0; i < length; i++) buf[i] = Math.floor(random() * 256);
+  return buf;
+}
+
+function randomName(random, index) {
+  const unicodeBits = ['a', 'é', '日', '🙂', 'z'];
+  const segment = unicodeBits[Math.floor(random() * unicodeBits.length)];
+  return `dir-${index}/${segment}-${index}.bin`;
+}
+
+async function buildTree(random, count) {
+  const specs = [];
+  for (let i = 0; i < count; i++) {
+    const size = Math.floor(random() * 4096);
+    specs.push({
+      name: randomName(random, i),
+      data: randomBuffer(random, size),
+      method: random() < 0.5 ? 'deflate' : 'store',
+      mode: random() < 0.5 ? 0o644 : 0o600,
+      modified: new Date(2000 + Math.floor(random() * 40), Math.floor(random() * 12),
+                         1 + Math.floor(random() * 27)),
+    });
+  }
+  const entries = [];
+  for (const spec of specs) {
+    entries.push(await zlib.ZipEntry.create(spec.name, spec.data, {
+      method: spec.method, mode: spec.mode, modified: spec.modified,
+    }));
+  }
+  const chunks = [];
+  for await (const chunk of zlib.createZipArchive(entries)) chunks.push(chunk);
+  return { archive: Buffer.concat(chunks), specs };
+}
+
+test('random archives round-trip through ZipEntry.read, ZipBuffer, and ZipFile', async () => {
+  const random = mulberry32(0xC0FFEE);
+  const rounds = 8;
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'zlib-zip-property-'));
+  try {
+    for (let round = 0; round < rounds; round++) {
+      const { archive, specs } = await buildTree(random, 6);
+      const byName = new Map(specs.map((spec) => [spec.name, spec]));
+
+      // Path 1: ZipEntry.read
+      for (const entry of zlib.ZipEntry.read(archive)) {
+        const spec = byName.get(entry.name);
+        assert.ok(spec, `unexpected entry ${entry.name}`);
+        assert.deepStrictEqual(await entry.content(), spec.data);
+        assert.strictEqual(entry.mode, spec.mode);
+      }
+
+      // Path 2: ZipBuffer
+      using zipBuffer = new zlib.ZipBuffer(archive);
+      assert.strictEqual(zipBuffer.size, specs.length);
+      for (const [name, entry] of zipBuffer) {
+        const spec = byName.get(name);
+        assert.deepStrictEqual(await entry.content(), spec.data);
+      }
+
+      // Path 3: ZipFile (disk-backed), including one streamed read.
+      const filePath = path.join(dir, `round-${round}.zip`);
+      await fs.writeFile(filePath, archive);
+      const zipFile = await zlib.ZipFile.open(filePath);
+      try {
+        assert.strictEqual(zipFile.size, specs.length);
+        for (const spec of specs) {
+          const entry = await zipFile.get(spec.name);
+          assert.deepStrictEqual(await entry.content(), spec.data);
+        }
+        const firstName = specs[0].name;
+        const streamed = [];
+        for await (const chunk of await zipFile.stream(firstName)) streamed.push(chunk);
+        assert.deepStrictEqual(Buffer.concat(streamed), specs[0].data);
+      } finally {
+        await zipFile.close();
+      }
+    }
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}, { timeout: 60_000 });
+
+test('a streamed write round-trips through a streamed read', async () => {
+  const random = mulberry32(0xBADF00D);
+  const data = randomBuffer(random, 256 * 1024);
+  async function* source() {
+    for (let i = 0; i < data.length; i += 4096) {
+      yield data.subarray(i, Math.min(i + 4096, data.length));
+    }
+  }
+  const entry = zlib.ZipEntry.createStream('streamed.bin', source());
+  const chunks = [];
+  for await (const chunk of zlib.createZipArchive([entry])) chunks.push(chunk);
+  const archive = Buffer.concat(chunks);
+
+  const [read] = zlib.ZipEntry.read(archive);
+  assert.strictEqual(read.name, 'streamed.bin');
+  assert.strictEqual(read.size, data.length);
+  const streamedOut = [];
+  for await (const chunk of read.contentIterator()) streamedOut.push(chunk);
+  assert.deepStrictEqual(Buffer.concat(streamedOut), data);
+});

--- a/test/parallel/test-zlib-zip-sync.js
+++ b/test/parallel/test-zlib-zip-sync.js
@@ -1,0 +1,245 @@
+'use strict';
+
+require('../common');
+
+const assert = require('node:assert');
+const zlib = require('node:zlib');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { test } = require('node:test');
+
+function buildArchiveSync(entries, comment) {
+  const chunks = [];
+  for (const chunk of zlib.createZipArchiveSync(entries, comment)) chunks.push(chunk);
+  return Buffer.concat(chunks);
+}
+
+function createTempZipSync(entries, comment) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'zlib-zip-sync-'));
+  const filePath = path.join(dir, 'archive.zip');
+  fs.writeFileSync(filePath, buildArchiveSync(entries, comment));
+  return { filePath, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
+}
+
+// -- ZipEntry -----------------------------------------------------------------
+
+test('ZipEntry.createSync()/contentSync() round-trip, deflate and store', () => {
+  const deflateEntry = zlib.ZipEntry.createSync('a.txt', Buffer.from('a'.repeat(1000)));
+  assert.strictEqual(deflateEntry.method, 8);
+  assert.strictEqual(deflateEntry.contentSync().toString(), 'a'.repeat(1000));
+
+  const storeEntry = zlib.ZipEntry.createSync('b.bin', Buffer.from([1, 2, 3]), { method: 'store' });
+  assert.strictEqual(storeEntry.method, 0);
+  assert.deepStrictEqual(storeEntry.contentSync(), Buffer.from([1, 2, 3]));
+
+  // Matches the crc32/size that the async ZipEntry.create() would produce.
+  const data = Buffer.from('some content to compare');
+  assert.strictEqual(zlib.ZipEntry.createSync('x', data).crc32, zlib.crc32(data));
+});
+
+test('ZipEntry.createSync()/contentSync() round-trip, zstd', () => {
+  const zstdEntry = zlib.ZipEntry.createSync('z.txt', Buffer.from('z'.repeat(1000)), { method: 'zstd' });
+  assert.strictEqual(zstdEntry.method, 93);
+  assert.strictEqual(zstdEntry.contentSync().toString(), 'z'.repeat(1000));
+});
+
+test('ZipEntry.contentSync() enforces maxSize and CRC verification like content()', () => {
+  const entry = zlib.ZipEntry.createSync('a.txt', Buffer.from('hello world'), { method: 'store' });
+  assert.throws(() => entry.contentSync({ maxSize: 1 }), { code: 'ERR_ZIP_ENTRY_TOO_LARGE' });
+
+  const archive = buildArchiveSync([entry]);
+  const tampered = Buffer.from(archive);
+  tampered[30 + 'a.txt'.length] ^= 0xff; // Flip a content byte.
+  const [tamperedEntry] = zlib.ZipEntry.read(tampered);
+  assert.throws(() => tamperedEntry.contentSync(), { code: 'ERR_ZIP_ENTRY_CORRUPT' });
+  assert.strictEqual(tamperedEntry.contentSync({ verify: false }).length, 'hello world'.length);
+});
+
+test('createZipArchiveSync() throws for a streaming (pending) entry', () => {
+  const streaming = zlib.ZipEntry.createStream('big.bin', (async function* () {})());
+  assert.throws(() => [...zlib.createZipArchiveSync([streaming])], { code: 'ERR_INVALID_STATE' });
+});
+
+// -- ZipBuffer ----------------------------------------------------------------
+
+test('ZipBuffer.addSync()/toBufferSync() round-trip', () => {
+  const archive = buildArchiveSync([zlib.ZipEntry.createSync('a.txt', Buffer.from('a'))], 'a comment');
+  using zip = new zlib.ZipBuffer(archive);
+  const added = zip.addSync('b.txt', Buffer.from('b'));
+  assert.strictEqual(added.name, 'b.txt');
+  assert.strictEqual(zip.size, 2);
+
+  const rebuilt = zip.toBufferSync();
+  using reread = new zlib.ZipBuffer(rebuilt);
+  assert.deepStrictEqual([...reread.keys()].sort(), ['a.txt', 'b.txt']);
+  assert.strictEqual(reread.get('a.txt').contentSync().toString(), 'a');
+  assert.strictEqual(reread.get('b.txt').contentSync().toString(), 'b');
+  assert.strictEqual(reread.comment, 'a comment');
+});
+
+// -- ZipFile ------------------------------------------------------------------
+
+test('ZipFile.openSync() reads the same entries as open()', async () => {
+  const { filePath, cleanup } = createTempZipSync([
+    zlib.ZipEntry.createSync('a.txt', Buffer.from('a')),
+    zlib.ZipEntry.createSync('b.bin', Buffer.from([1, 2, 3]), { method: 'store' }),
+  ]);
+  try {
+    const zip = zlib.ZipFile.openSync(filePath);
+    try {
+      assert.strictEqual(zip.writable, false);
+      assert.strictEqual(zip.size, 2);
+      assert.strictEqual(zip.getSync('a.txt').contentSync().toString(), 'a');
+      assert.deepStrictEqual(zip.getSync('b.bin').contentSync(), Buffer.from([1, 2, 3]));
+      assert.deepStrictEqual([...zip.valuesSync()].map((e) => e.name).sort(), ['a.txt', 'b.bin']);
+      assert.deepStrictEqual([...zip.entriesSync()].map(([n]) => n).sort(), ['a.txt', 'b.bin']);
+      const seen = [];
+      zip.forEachSync((entry, name) => seen.push(name));
+      assert.deepStrictEqual(seen.sort(), ['a.txt', 'b.bin']);
+    } finally {
+      zip.closeSync();
+    }
+
+    const asyncZip = await zlib.ZipFile.open(filePath);
+    try {
+      assert.deepStrictEqual([...asyncZip.keys()].sort(), ['a.txt', 'b.bin']);
+    } finally {
+      await asyncZip.close();
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('ZipFile opened via openSync supports `using` (Symbol.dispose)', () => {
+  const { filePath, cleanup } = createTempZipSync([zlib.ZipEntry.createSync('a.txt', Buffer.from('a'))]);
+  try {
+    {
+      using zip = zlib.ZipFile.openSync(filePath);
+      assert.strictEqual(zip.getSync('a.txt').contentSync().toString(), 'a');
+    }
+    // Disposed: the fd should be closed. Re-opening the same path must still work.
+    const reopened = zlib.ZipFile.openSync(filePath);
+    reopened.closeSync();
+  } finally {
+    cleanup();
+  }
+});
+
+test('ZipFile.addEntrySync()/addSync()/deleteSync() alter the file synchronously', () => {
+  const { filePath, cleanup } = createTempZipSync([
+    zlib.ZipEntry.createSync('a.txt', Buffer.from('AAAA'.repeat(20))),
+    zlib.ZipEntry.createSync('b.bin', Buffer.from([1, 2, 3]), { method: 'store' }),
+  ]);
+  try {
+    const zip = zlib.ZipFile.openSync(filePath, { writable: true });
+    try {
+      assert.strictEqual(zip.writable, true);
+      const sizeBefore = fs.statSync(filePath).size;
+      const added = zip.addSync('c.txt', Buffer.from('a fresh member'));
+      assert.strictEqual(added.name, 'c.txt');
+      assert.strictEqual(zip.size, 3);
+      assert.ok(fs.statSync(filePath).size > sizeBefore);
+      assert.strictEqual(zip.getSync('c.txt').contentSync().toString(), 'a fresh member');
+      // Original entries untouched.
+      assert.strictEqual(zip.getSync('a.txt').contentSync().toString(), 'AAAA'.repeat(20));
+
+      const entry = zlib.ZipEntry.createSync('d.txt', Buffer.from('d'));
+      assert.strictEqual(zip.addEntrySync(entry), entry);
+
+      const sizeBeforeDelete = fs.statSync(filePath).size;
+      assert.strictEqual(zip.deleteSync('b.bin'), true);
+      assert.ok(fs.statSync(filePath).size < sizeBeforeDelete);
+      assert.strictEqual(zip.deleteSync('does-not-exist'), false);
+    } finally {
+      zip.closeSync();
+    }
+
+    const reread = zlib.ZipFile.openSync(filePath);
+    try {
+      assert.deepStrictEqual([...reread.keys()].sort(), ['a.txt', 'c.txt', 'd.txt']);
+    } finally {
+      reread.closeSync();
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('ZipFile.addEntrySync() rejects a pending streaming entry', () => {
+  const { filePath, cleanup } = createTempZipSync([zlib.ZipEntry.createSync('a.txt', Buffer.from('a'))]);
+  try {
+    const zip = zlib.ZipFile.openSync(filePath, { writable: true });
+    try {
+      const streaming = zlib.ZipEntry.createStream('big.bin', (async function* () {})());
+      assert.throws(() => zip.addEntrySync(streaming), { code: 'ERR_INVALID_STATE' });
+    } finally {
+      zip.closeSync();
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('ZipFile sync mutators throw ERR_ZIP_NOT_WRITABLE when not opened writable', () => {
+  const { filePath, cleanup } = createTempZipSync([zlib.ZipEntry.createSync('a.txt', Buffer.from('a'))]);
+  try {
+    const zip = zlib.ZipFile.openSync(filePath);
+    try {
+      assert.throws(() => zip.addSync('b.txt', Buffer.from('b')), { code: 'ERR_ZIP_NOT_WRITABLE' });
+      assert.throws(() => zip.deleteSync('a.txt'), { code: 'ERR_ZIP_NOT_WRITABLE' });
+    } finally {
+      zip.closeSync();
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('ZipFile.compactSync() matches compact() and does not touch the open file', () => {
+  const { filePath, cleanup } = createTempZipSync([
+    zlib.ZipEntry.createSync('a.txt', Buffer.from('a'.repeat(1000))),
+    zlib.ZipEntry.createSync('b.txt', Buffer.from('b'.repeat(1000))),
+  ]);
+  try {
+    const zip = zlib.ZipFile.openSync(filePath, { writable: true });
+    try {
+      zip.deleteSync('b.txt');
+      const sizeWithDeadSpace = fs.statSync(filePath).size;
+      const compacted = zip.compactSync();
+      assert.strictEqual(fs.statSync(filePath).size, sizeWithDeadSpace);
+      assert.ok(compacted.length < sizeWithDeadSpace);
+      using reread = new zlib.ZipBuffer(compacted);
+      assert.deepStrictEqual([...reread.keys()], ['a.txt']);
+    } finally {
+      zip.closeSync();
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('a sync ZipFile method throws while an async mutation has not settled yet', async () => {
+  const { filePath, cleanup } = createTempZipSync([zlib.ZipEntry.createSync('seed.txt', Buffer.from('seed'))]);
+  try {
+    const zip = await zlib.ZipFile.open(filePath, { writable: true });
+    try {
+      // addEntry() (unlike add()) increments the busy counter synchronously,
+      // at call time - before any internal awaiting - so the checks below
+      // are guaranteed to observe the archive as busy.
+      const entry = zlib.ZipEntry.createSync('slow.txt', Buffer.from('x'));
+      const pending = zip.addEntry(entry);
+      assert.throws(() => zip.getSync('seed.txt'), { code: 'ERR_INVALID_STATE' });
+      assert.throws(() => zip.addSync('y.txt', Buffer.from('y')), { code: 'ERR_INVALID_STATE' });
+      assert.throws(() => zip.closeSync(), { code: 'ERR_INVALID_STATE' });
+      await pending;
+      // Once settled, sync methods work again.
+      assert.strictEqual(zip.getSync('seed.txt').contentSync().toString(), 'seed');
+    } finally {
+      await zip.close();
+    }
+  } finally {
+    cleanup();
+  }
+});

--- a/test/parallel/test-zlib-zip-vfs.js
+++ b/test/parallel/test-zlib-zip-vfs.js
@@ -1,0 +1,183 @@
+// Flags: --experimental-vfs
+'use strict';
+
+// Exercises the node:zlib ZipFile read/write surface over a node:vfs virtual
+// file descriptor. An in-memory archive is placed in a mounted MemoryProvider
+// VFS and opened with ZipFile through its mounted path, so every fd operation
+// ZipFile performs - positional read/write, fstat, ftruncate, open/close, in
+// both the asynchronous and the synchronous flavour - is served by the VFS
+// rather than a real OS fd. This validates that ZipFile's fd abstraction is
+// complete enough to run unchanged on a purely virtual descriptor.
+
+require('../common');
+
+const assert = require('node:assert');
+const zlib = require('node:zlib');
+const fs = require('node:fs');
+const path = require('node:path');
+const { test } = require('node:test');
+const vfs = require('node:vfs');
+
+let mountCounter = 0;
+
+async function buildArchive(entries, comment) {
+  const chunks = [];
+  for await (const chunk of zlib.createZipArchive(entries, comment)) chunks.push(chunk);
+  return Buffer.concat(chunks);
+}
+
+// Places `archive` in a freshly mounted in-memory VFS and returns the mounted
+// path of the archive file plus a cleanup that unmounts the VFS.
+function mountArchive(archive) {
+  const mountPoint = path.resolve(`/vfs-zip-${process.pid}-${mountCounter++}`);
+  const memfs = vfs.create();
+  memfs.writeFileSync('/archive.zip', archive); // provider-relative, before mount
+  memfs.mount(mountPoint);
+  return { vpath: path.join(mountPoint, 'archive.zip'), cleanup: () => memfs.unmount() };
+}
+
+test('ZipFile.open() reads a VFS-backed archive through an async virtual fd', async () => {
+  const archive = await buildArchive([
+    await zlib.ZipEntry.create('a.txt', Buffer.from('hello vfs')),
+    await zlib.ZipEntry.create('dir/b.bin', Buffer.from([1, 2, 3, 4]), { method: 'store' }),
+    await zlib.ZipEntry.create('z.txt', Buffer.from('Z'.repeat(4096)), { method: 'zstd' }),
+  ]);
+  const { vpath, cleanup } = mountArchive(archive);
+  try {
+    const zf = await zlib.ZipFile.open(vpath);
+    try {
+      assert.strictEqual(zf.size, 3);
+      assert.deepStrictEqual([...zf.keys()].sort(), ['a.txt', 'dir/b.bin', 'z.txt']);
+
+      // A lazy, file-backed entry: it retains no content and reads straight
+      // from the virtual fd on demand.
+      const a = await zf.get('a.txt');
+      assert.strictEqual(a.rawContent, null);
+      assert.strictEqual((await a.content()).toString(), 'hello vfs');
+      assert.strictEqual(await zf.get('a.txt'), a); // Cached handle identity
+
+      // The contentIterator() streams (decompressing on the way) from the fd.
+      const chunks = [];
+      for await (const c of (await zf.get('z.txt')).contentIterator()) chunks.push(c);
+      assert.strictEqual(Buffer.concat(chunks).toString(), 'Z'.repeat(4096));
+
+      // stream() resolves to a Readable over the virtual fd.
+      const rs = await zf.stream('dir/b.bin');
+      const out = [];
+      for await (const c of rs) out.push(c);
+      assert.deepStrictEqual(Buffer.concat(out), Buffer.from([1, 2, 3, 4]));
+    } finally {
+      await zf.close();
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('ZipFile.openSync() reads a VFS-backed archive through a synchronous virtual fd', async () => {
+  const archive = await buildArchive([
+    await zlib.ZipEntry.create('a.txt', Buffer.from('sync hello')),
+    await zlib.ZipEntry.create('b.bin', Buffer.from([9, 8, 7]), { method: 'store' }),
+  ]);
+  const { vpath, cleanup } = mountArchive(archive);
+  try {
+    const zf = zlib.ZipFile.openSync(vpath);
+    try {
+      assert.strictEqual(zf.getSync('a.txt').contentSync().toString(), 'sync hello');
+      assert.deepStrictEqual([...zf.getSync('b.bin').contentSync()], [9, 8, 7]);
+      assert.deepStrictEqual([...zf.valuesSync()].map((e) => e.name).sort(), ['a.txt', 'b.bin']);
+    } finally {
+      zf.closeSync();
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('ZipFile writable mutations run against an async virtual fd', async () => {
+  const archive = await buildArchive([
+    await zlib.ZipEntry.create('keep.txt', Buffer.from('keep')),
+    await zlib.ZipEntry.create('drop.txt', Buffer.from('drop')),
+  ]);
+  const { vpath, cleanup } = mountArchive(archive);
+  try {
+    const sizeBefore = fs.statSync(vpath).size;
+    const zw = await zlib.ZipFile.open(vpath, { writable: true });
+    try {
+      await zw.add('added.txt', Buffer.from('a new member over vfs'));
+      assert.strictEqual(await zw.delete('drop.txt'), true);
+    } finally {
+      await zw.close();
+    }
+    // Positional writes + ftruncate actually altered the virtual file.
+    assert.notStrictEqual(fs.statSync(vpath).size, sizeBefore);
+
+    const zr = await zlib.ZipFile.open(vpath);
+    try {
+      assert.deepStrictEqual([...zr.keys()].sort(), ['added.txt', 'keep.txt']);
+      assert.strictEqual((await (await zr.get('added.txt')).content()).toString(), 'a new member over vfs');
+      assert.strictEqual(zr.has('drop.txt'), false);
+    } finally {
+      await zr.close();
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('ZipFile sync mutations (addEntrySync) run against a synchronous virtual fd', async () => {
+  const archive = await buildArchive([await zlib.ZipEntry.create('a.txt', Buffer.from('a'))]);
+  const { vpath, cleanup } = mountArchive(archive);
+  try {
+    const zw = zlib.ZipFile.openSync(vpath, { writable: true });
+    try {
+      zw.addSync('b.txt', Buffer.from('b sync'));
+      assert.deepStrictEqual([...zw.keys()].sort(), ['a.txt', 'b.txt']);
+    } finally {
+      zw.closeSync();
+    }
+    const zr = zlib.ZipFile.openSync(vpath);
+    try {
+      assert.strictEqual(zr.getSync('b.txt').contentSync().toString(), 'b sync');
+    } finally {
+      zr.closeSync();
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('addEntry() promotes a streaming entry to file-backed on a virtual fd', async () => {
+  const archive = await buildArchive([await zlib.ZipEntry.create('seed.txt', Buffer.from('seed'))]);
+  const { vpath, cleanup } = mountArchive(archive);
+  try {
+    const payload = 'streamed over vfs'.repeat(32);
+    const zw = await zlib.ZipFile.open(vpath, { writable: true });
+    try {
+      async function* source() {
+        yield Buffer.from(payload.slice(0, 5));
+        yield Buffer.from(payload.slice(5));
+      }
+      const streamEntry = zlib.ZipEntry.createStream('s.txt', source());
+      const returned = await zw.addEntry(streamEntry);
+      assert.strictEqual(returned, streamEntry);
+
+      // Promoted in place against the virtual fd: now readable and re-streamable.
+      assert.strictEqual((await streamEntry.content()).toString(), payload);
+      const it = [];
+      for await (const c of streamEntry.contentIterator()) it.push(c);
+      assert.strictEqual(Buffer.concat(it).toString(), payload);
+    } finally {
+      await zw.close();
+    }
+
+    const zr = await zlib.ZipFile.open(vpath);
+    try {
+      assert.strictEqual((await (await zr.get('s.txt')).content()).toString(), payload);
+    } finally {
+      await zr.close();
+    }
+  } finally {
+    cleanup();
+  }
+});

--- a/test/parallel/test-zlib-zip-writable.js
+++ b/test/parallel/test-zlib-zip-writable.js
@@ -1,0 +1,301 @@
+'use strict';
+
+require('../common');
+
+const assert = require('node:assert');
+const zlib = require('node:zlib');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const os = require('node:os');
+const { test } = require('node:test');
+
+async function buildArchive(entries, comment) {
+  const chunks = [];
+  for await (const chunk of zlib.createZipArchive(entries, comment)) chunks.push(chunk);
+  return Buffer.concat(chunks);
+}
+
+async function createTempZip(entries, comment) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'zlib-zip-writable-'));
+  const filePath = path.join(dir, 'archive.zip');
+  await fs.writeFile(filePath, await buildArchive(entries, comment));
+  return { filePath, cleanup: () => fs.rm(dir, { recursive: true, force: true }) };
+}
+
+// -- ZipBuffer --------------------------------------------------------------
+
+test('ZipBuffer is always writable', async () => {
+  const archive = await buildArchive([]);
+  using zip = new zlib.ZipBuffer(archive);
+  assert.strictEqual(zip.writable, true);
+});
+
+test('ZipBuffer preserves the archive comment across toBuffer()', async () => {
+  const archive = await buildArchive([], 'original comment');
+  using zip = new zlib.ZipBuffer(archive);
+  assert.strictEqual(zip.comment, 'original comment');
+  const rebuilt = await zip.toBuffer();
+  using reread = new zlib.ZipBuffer(rebuilt);
+  assert.strictEqual(reread.comment, 'original comment');
+});
+
+test('ZipBuffer add()/addEntry()/delete()/clear() mutate the in-memory index', async () => {
+  const archive = await buildArchive([
+    await zlib.ZipEntry.create('a.txt', Buffer.from('a')),
+  ]);
+  using zip = new zlib.ZipBuffer(archive);
+  assert.strictEqual(zip.size, 1);
+
+  const added = await zip.add('b.txt', Buffer.from('b'));
+  assert.strictEqual(added.name, 'b.txt');
+  assert.strictEqual(zip.size, 2);
+  assert.strictEqual(zip.has('b.txt'), true);
+
+  const entry = await zlib.ZipEntry.create('c.txt', Buffer.from('c'));
+  assert.strictEqual(zip.addEntry(entry), entry);
+  assert.strictEqual(zip.size, 3);
+
+  assert.strictEqual(zip.delete('a.txt'), true);
+  assert.strictEqual(zip.delete('a.txt'), false);
+  assert.strictEqual(zip.size, 2);
+
+  zip.clear();
+  assert.strictEqual(zip.size, 0);
+});
+
+test('ZipBuffer.toBuffer() serializes the current live set, replacing on overwrite', async () => {
+  const archive = await buildArchive([
+    await zlib.ZipEntry.create('a.txt', Buffer.from('original')),
+    await zlib.ZipEntry.create('b.txt', Buffer.from('keep')),
+  ]);
+  using zip = new zlib.ZipBuffer(archive);
+  await zip.add('a.txt', Buffer.from('replaced'));
+  zip.delete('b.txt');
+  await zip.add('c.txt', Buffer.from('new'));
+
+  const rebuilt = await zip.toBuffer();
+  using reread = new zlib.ZipBuffer(rebuilt);
+  assert.deepStrictEqual([...reread.keys()].sort(), ['a.txt', 'c.txt']);
+  assert.strictEqual((await reread.get('a.txt').content()).toString(), 'replaced');
+  assert.strictEqual((await reread.get('c.txt').content()).toString(), 'new');
+});
+
+test('ZipBuffer.addEntry() rejects a non-ZipEntry value', async () => {
+  const archive = await buildArchive([]);
+  using zip = new zlib.ZipBuffer(archive);
+  assert.throws(() => zip.addEntry({ name: 'fake.txt' }), { code: 'ERR_INVALID_ARG_TYPE' });
+});
+
+// -- ZipFile ------------------------------------------------------------------
+
+test('ZipFile defaults to read-only and rejects mutation', async () => {
+  const { filePath, cleanup } = await createTempZip([await zlib.ZipEntry.create('a.txt', Buffer.from('a'))]);
+  try {
+    const zip = await zlib.ZipFile.open(filePath);
+    try {
+      assert.strictEqual(zip.writable, false);
+      await assert.rejects(zip.add('b.txt', Buffer.from('b')), { code: 'ERR_ZIP_NOT_WRITABLE' });
+      await assert.rejects(zip.delete('a.txt'), { code: 'ERR_ZIP_NOT_WRITABLE' });
+    } finally {
+      await zip.close();
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+test('ZipFile opened writable: addEntry() appends where the old CD used to be', async () => {
+  const { filePath, cleanup } = await createTempZip([
+    await zlib.ZipEntry.create('a.txt', Buffer.from('AAAA'.repeat(20))),
+    await zlib.ZipEntry.create('b.bin', Buffer.from([1, 2, 3]), { method: 'store' }),
+  ]);
+  try {
+    const sizeBefore = (await fs.stat(filePath)).size;
+    const zip = await zlib.ZipFile.open(filePath, { writable: true });
+    try {
+      assert.strictEqual(zip.writable, true);
+      const added = await zip.add('c.txt', Buffer.from('a fresh member'));
+      assert.strictEqual(added.name, 'c.txt');
+      assert.strictEqual(zip.size, 3);
+
+      // The file must actually be altered by the time the call returns.
+      const sizeAfter = (await fs.stat(filePath)).size;
+      assert.ok(sizeAfter > sizeBefore);
+
+      // Original entries must be untouched.
+      assert.strictEqual((await (await zip.get('a.txt')).content()).toString(), 'AAAA'.repeat(20));
+      assert.deepStrictEqual(await (await zip.get('b.bin')).content(), Buffer.from([1, 2, 3]));
+      assert.strictEqual((await (await zip.get('c.txt')).content()).toString(), 'a fresh member');
+    } finally {
+      await zip.close();
+    }
+
+    // Re-opening from scratch must see the same three entries.
+    const reread = await zlib.ZipFile.open(filePath);
+    try {
+      assert.deepStrictEqual([...reread.keys()].sort(), ['a.txt', 'b.bin', 'c.txt']);
+    } finally {
+      await reread.close();
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+test('ZipFile addEntry() promotes a spent streaming entry into a readable file-backed entry', async () => {
+  const { filePath, cleanup } = await createTempZip([
+    await zlib.ZipEntry.create('seed.txt', Buffer.from('seed')),
+  ]);
+  try {
+    const zip = await zlib.ZipFile.open(filePath, { writable: true });
+    try {
+      const payload = 'streamed payload'.repeat(64);
+      async function* source() {
+        yield Buffer.from(payload.slice(0, 10));
+        yield Buffer.from(payload.slice(10));
+      }
+      const streamEntry = zlib.ZipEntry.createStream('s.txt', source());
+
+      // Before it is written, a streaming entry has no readable content.
+      await assert.rejects(streamEntry.content(), { code: 'ERR_INVALID_STATE' });
+
+      const returned = await zip.addEntry(streamEntry);
+      // addEntry() returns the same object, now promoted in place.
+      assert.strictEqual(returned, streamEntry);
+
+      // The once-spent entry is now readable, both buffered and streamed.
+      assert.strictEqual((await streamEntry.content()).toString(), payload);
+      const chunks = [];
+      for await (const chunk of streamEntry.contentIterator()) chunks.push(chunk);
+      assert.strictEqual(Buffer.concat(chunks).toString(), payload);
+
+      // And re-serializable: it can be copied into a fresh archive.
+      const copy = new zlib.ZipBuffer(await buildArchive([streamEntry]));
+      assert.strictEqual(copy.get('s.txt').contentSync().toString(), payload);
+      assert.strictEqual(copy.get('s.txt').crc32 >>> 0, streamEntry.crc32 >>> 0);
+
+      // An in-memory entry added alongside keeps its own buffer (not promoted).
+      const mem = await zlib.ZipEntry.create('m.txt', Buffer.from('in memory'));
+      await zip.addEntry(mem);
+      assert.deepStrictEqual(mem.rawContent, mem.rawContent); // still a Buffer
+      assert.notStrictEqual(mem.rawContent, null);
+    } finally {
+      await zip.close();
+    }
+
+    // The bytes persisted correctly and re-open sees the streamed member.
+    const reread = await zlib.ZipFile.open(filePath);
+    try {
+      assert.strictEqual(
+        (await (await reread.get('s.txt')).content()).toString(),
+        'streamed payload'.repeat(64));
+    } finally {
+      await reread.close();
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+test('ZipFile opened writable: delete() rewrites the CD without growing the file', async () => {
+  const { filePath, cleanup } = await createTempZip([
+    await zlib.ZipEntry.create('a.txt', Buffer.from('a')),
+    await zlib.ZipEntry.create('b.txt', Buffer.from('b')),
+  ]);
+  try {
+    const zip = await zlib.ZipFile.open(filePath, { writable: true });
+    try {
+      const sizeBefore = (await fs.stat(filePath)).size;
+      assert.strictEqual(await zip.delete('b.txt'), true);
+      const sizeAfter = (await fs.stat(filePath)).size;
+      assert.ok(sizeAfter < sizeBefore);
+      assert.strictEqual(zip.has('b.txt'), false);
+      assert.strictEqual(zip.size, 1);
+      assert.strictEqual(await zip.delete('does-not-exist'), false);
+    } finally {
+      await zip.close();
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+test('ZipFile.compact() streams a fresh archive with no dead entries and does not touch the open file', async () => {
+  const { filePath, cleanup } = await createTempZip([
+    await zlib.ZipEntry.create('a.txt', Buffer.from('a'.repeat(1000))),
+    await zlib.ZipEntry.create('b.txt', Buffer.from('b'.repeat(1000))),
+  ]);
+  try {
+    const zip = await zlib.ZipFile.open(filePath, { writable: true });
+    try {
+      await zip.delete('b.txt'); // Leaves dead space behind
+      const sizeWithDeadSpace = (await fs.stat(filePath)).size;
+
+      const chunks = [];
+      for await (const chunk of zip.compact()) chunks.push(chunk);
+      const compacted = Buffer.concat(chunks);
+
+      // compact() must not have modified the still-open file.
+      assert.strictEqual((await fs.stat(filePath)).size, sizeWithDeadSpace);
+
+      assert.ok(compacted.length < sizeWithDeadSpace);
+      using reread = new zlib.ZipBuffer(compacted);
+      assert.deepStrictEqual([...reread.keys()], ['a.txt']);
+      assert.strictEqual((await reread.get('a.txt').content()).toString(), 'a'.repeat(1000));
+    } finally {
+      await zip.close();
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+test('ZipFile preserves the archive comment across writes', async () => {
+  const { filePath, cleanup } = await createTempZip(
+    [await zlib.ZipEntry.create('a.txt', Buffer.from('a'))], 'a comment');
+  try {
+    const zip = await zlib.ZipFile.open(filePath, { writable: true });
+    try {
+      assert.strictEqual(zip.comment, 'a comment');
+      await zip.add('b.txt', Buffer.from('b'));
+      assert.strictEqual(zip.comment, 'a comment');
+    } finally {
+      await zip.close();
+    }
+    const reread = await zlib.ZipFile.open(filePath);
+    try {
+      assert.strictEqual(reread.comment, 'a comment');
+    } finally {
+      await reread.close();
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+test('ZipFile serializes concurrent add()/delete() calls instead of racing', async () => {
+  const { filePath, cleanup } = await createTempZip([await zlib.ZipEntry.create('seed.txt', Buffer.from('seed'))]);
+  try {
+    const zip = await zlib.ZipFile.open(filePath, { writable: true });
+    try {
+      const names = [];
+      for (let i = 0; i < 20; i++) names.push(`f${i}.txt`);
+      await Promise.all(names.map((name) => zip.add(name, Buffer.from(name))));
+      assert.strictEqual(zip.size, names.length + 1);
+      for (const name of names) {
+        assert.strictEqual((await (await zip.get(name)).content()).toString(), name);
+      }
+    } finally {
+      await zip.close();
+    }
+
+    const reread = await zlib.ZipFile.open(filePath);
+    try {
+      assert.strictEqual(reread.size, 21);
+    } finally {
+      await reread.close();
+    }
+  } finally {
+    await cleanup();
+  }
+}, { timeout: 30_000 });

--- a/test/parallel/test-zlib-zip-zip64.js
+++ b/test/parallel/test-zlib-zip-zip64.js
@@ -1,0 +1,38 @@
+'use strict';
+
+require('../common');
+
+const assert = require('node:assert');
+const zlib = require('node:zlib');
+const { test } = require('node:test');
+
+const ZIP64_EOCD_SIGNATURE = Buffer.from([0x50, 0x4b, 0x06, 0x06]);
+
+async function buildArchive(count) {
+  const entries = [];
+  for (let i = 0; i < count; i++) {
+    entries.push(await zlib.ZipEntry.create(`entry-${i}`, Buffer.alloc(0), { method: 'store' }));
+  }
+  const chunks = [];
+  for await (const chunk of zlib.createZipArchive(entries)) chunks.push(chunk);
+  return Buffer.concat(chunks);
+}
+
+test('an entry count at or above 0xFFFF forces Zip64 structures', async () => {
+  const archive = await buildArchive(0x10000);
+  assert.ok(archive.includes(ZIP64_EOCD_SIGNATURE));
+
+  const read = [...zlib.ZipEntry.read(archive)];
+  assert.strictEqual(read.length, 0x10000);
+
+  using zip = new zlib.ZipBuffer(archive);
+  assert.strictEqual(zip.size, 0x10000);
+  assert.strictEqual(zip.has('entry-0'), true);
+  assert.strictEqual(zip.has(`entry-${0x10000 - 1}`), true);
+}, { timeout: 120_000 });
+
+test('an archive below the Zip64 thresholds contains no Zip64 structures', async () => {
+  const archive = await buildArchive(10);
+  assert.ok(!archive.includes(ZIP64_EOCD_SIGNATURE));
+  assert.strictEqual([...zlib.ZipEntry.read(archive)].length, 10);
+});

--- a/test/parallel/test-zlib-zip.js
+++ b/test/parallel/test-zlib-zip.js
@@ -1,0 +1,112 @@
+'use strict';
+
+require('../common');
+
+const assert = require('node:assert');
+const zlib = require('node:zlib');
+const { test } = require('node:test');
+
+async function buildArchive(entries, comment) {
+  const chunks = [];
+  for await (const chunk of zlib.createZipArchive(entries, comment)) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+test('round-trips a small archive through ZipEntry.read', async () => {
+  const entries = [
+    await zlib.ZipEntry.create('hello.txt', Buffer.from('Hello, world!'.repeat(20))),
+    await zlib.ZipEntry.create('raw.bin', Buffer.from([1, 2, 3, 4, 5]), { method: 'store' }),
+    await zlib.ZipEntry.create('empty.txt', Buffer.alloc(0)),
+    await zlib.ZipEntry.create('dir/', Buffer.alloc(0)),
+  ];
+  const archive = await buildArchive(entries, 'test comment');
+
+  const read = [...zlib.ZipEntry.read(archive)];
+  assert.strictEqual(read.length, 4);
+
+  const byName = new Map(read.map((entry) => [entry.name, entry]));
+  assert.strictEqual((await byName.get('hello.txt').content()).toString(),
+                     'Hello, world!'.repeat(20));
+  assert.strictEqual(byName.get('hello.txt').method, 8);
+  assert.deepStrictEqual(await byName.get('raw.bin').content(), Buffer.from([1, 2, 3, 4, 5]));
+  assert.strictEqual(byName.get('raw.bin').method, 0);
+  assert.strictEqual((await byName.get('empty.txt').content()).length, 0);
+  assert.strictEqual(byName.get('dir/').isDirectory, true);
+  assert.strictEqual(byName.get('hello.txt').isFile, true);
+});
+
+test('ZipBuffer indexes entries by name', async () => {
+  const entries = [
+    await zlib.ZipEntry.create('a.txt', Buffer.from('a')),
+    await zlib.ZipEntry.create('b.txt', Buffer.from('b')),
+  ];
+  const archive = await buildArchive(entries);
+  using zip = new zlib.ZipBuffer(archive);
+
+  assert.strictEqual(zip.size, 2);
+  assert.strictEqual(zip.has('a.txt'), true);
+  assert.strictEqual(zip.has('missing.txt'), false);
+  assert.strictEqual((await zip.get('a.txt').content()).toString(), 'a');
+  assert.deepStrictEqual([...zip.keys()].sort(), ['a.txt', 'b.txt']);
+
+  assert.throws(() => zip.get('missing.txt'), { code: 'ERR_ZIP_ENTRY_NOT_FOUND' });
+});
+
+test('an incompressible or empty entry falls back to store', async () => {
+  const random = require('node:crypto').randomBytes(4096);
+  const entry = await zlib.ZipEntry.create('random.bin', random);
+  assert.strictEqual(entry.method, 0);
+  assert.deepStrictEqual(await entry.content(), random);
+
+  const empty = await zlib.ZipEntry.create('empty.bin', Buffer.alloc(0));
+  assert.strictEqual(empty.method, 0);
+});
+
+test('explicit store option is honored even for compressible data', async () => {
+  const data = Buffer.from('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+  const entry = await zlib.ZipEntry.create('stored.txt', data, { method: 'store' });
+  assert.strictEqual(entry.method, 0);
+  assert.deepStrictEqual(entry.rawContent, data);
+});
+
+test('the zstd method compresses and round-trips through an archive', async () => {
+  const data = Buffer.from('zstd content '.repeat(200));
+  const entry = await zlib.ZipEntry.create('z.txt', data, { method: 'zstd' });
+  assert.strictEqual(entry.method, 93);
+  assert.ok(entry.compressedSize < data.length);
+  assert.deepStrictEqual(await entry.content(), data);
+
+  const archive = await buildArchive([entry]);
+  const [read] = zlib.ZipEntry.read(archive);
+  assert.strictEqual(read.method, 93);
+  assert.deepStrictEqual(await read.content(), data);
+});
+
+test('an incompressible entry with method zstd falls back to store', async () => {
+  const random = require('node:crypto').randomBytes(4096);
+  const entry = await zlib.ZipEntry.create('random.bin', random, { method: 'zstd' });
+  assert.strictEqual(entry.method, 0);
+  assert.deepStrictEqual(await entry.content(), random);
+});
+
+test('crc32 chains the same way as zlib.crc32', async () => {
+  const data = Buffer.from('the quick brown fox jumps over the lazy dog');
+  const entry = await zlib.ZipEntry.create('f.txt', data);
+  assert.strictEqual(entry.crc32, zlib.crc32(data));
+});
+
+test('createZipArchive rejects an overlong comment', async () => {
+  await assert.rejects(
+    buildArchive([], 'x'.repeat(70000)),
+    { code: 'ERR_ZIP_ENTRY_TOO_LARGE' },
+  );
+});
+
+test('directory entries cannot carry content', async () => {
+  await assert.rejects(
+    zlib.ZipEntry.create('dir/', Buffer.from('x')),
+    { code: 'ERR_INVALID_ARG_VALUE' },
+  );
+});

--- a/test/pummel/test-zlib-zip-slow.js
+++ b/test/pummel/test-zlib-zip-slow.js
@@ -1,0 +1,106 @@
+'use strict';
+
+// This test writes and reads back a ZIP archive whose total size exceeds
+// 4 GiB, to exercise the Zip64 promotion that is triggered by an offset or
+// size overflowing the classic 32-bit fields (as opposed to test-zlib-zip-
+// zip64.js in test/parallel, which triggers Zip64 through the 16-bit entry
+// count instead). It needs several GiB of free disk space and is too slow
+// for the default test run, hence living in test/pummel rather than
+// test/parallel.
+
+const common = require('../common');
+
+const assert = require('node:assert');
+const zlib = require('node:zlib');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const os = require('node:os');
+const { test } = require('node:test');
+
+const GiB = 1024 * 1024 * 1024;
+const MEMBER_SIZE = 500 * 1024 * 1024; // Four ~500 MiB stored members...
+const STORED_MEMBER_COUNT = 4;
+const STREAMED_MEMBER_SIZE = 2.5 * GiB; // ...plus one large streamed member:
+// total archive size is ~4.5 GiB, comfortably over the 4 GiB Zip64 offset
+// threshold. Required free space includes generous slack over that total.
+const REQUIRED_FREE_BYTES = 10 * GiB;
+const CHUNK_SIZE = 16 * 1024 * 1024;
+
+function fillChunk(seed) {
+  const chunk = Buffer.allocUnsafe(CHUNK_SIZE);
+  chunk.fill(seed & 0xff);
+  return chunk;
+}
+
+async function* repeatingChunks(totalSize, seed) {
+  let remaining = totalSize;
+  while (remaining > 0) {
+    const size = Math.min(CHUNK_SIZE, remaining);
+    const chunk = fillChunk(seed);
+    remaining -= size;
+    yield size === chunk.length ? chunk : chunk.subarray(0, size);
+  }
+}
+
+test('an archive larger than 4 GiB round-trips and triggers Zip64 via offset', async () => {
+  let free;
+  try {
+    const stats = await fs.statfs(os.tmpdir());
+    free = stats.bavail * stats.bsize;
+  } catch {
+    free = undefined;
+  }
+  if (free !== undefined && free < REQUIRED_FREE_BYTES) {
+    common.skip(`insufficient disk space in ${os.tmpdir()} for a >4 GiB archive test`);
+    return;
+  }
+
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'zlib-zip-slow-'));
+  const archivePath = path.join(dir, 'large.zip');
+  try {
+    const entries = [];
+    for (let i = 0; i < STORED_MEMBER_COUNT; i++) {
+      entries.push(zlib.ZipEntry.createStream(`stored-${i}.bin`, repeatingChunks(MEMBER_SIZE, i), {
+        method: 'store',
+      }));
+    }
+    entries.push(zlib.ZipEntry.createStream('streamed.bin', repeatingChunks(STREAMED_MEMBER_SIZE, 0xaa), {
+      method: 'store',
+    }));
+
+    const handle = await fs.open(archivePath, 'w');
+    try {
+      for await (const chunk of zlib.createZipArchive(entries)) {
+        await handle.write(chunk);
+      }
+    } finally {
+      await handle.close();
+    }
+
+    const stat = await fs.stat(archivePath);
+    assert.ok(stat.size > 4 * GiB, `archive is only ${stat.size} bytes`);
+
+    const zip = await zlib.ZipFile.open(archivePath);
+    try {
+      assert.strictEqual(zip.size, STORED_MEMBER_COUNT + 1);
+
+      let seen = 0;
+      for await (const chunk of await zip.stream('streamed.bin')) {
+        seen += chunk.length;
+        assert.strictEqual(chunk[0], 0xaa);
+      }
+      assert.strictEqual(seen, STREAMED_MEMBER_SIZE);
+
+      let storedSeen = 0;
+      for await (const chunk of await zip.stream('stored-2.bin')) {
+        storedSeen += chunk.length;
+        assert.strictEqual(chunk[0], 2);
+      }
+      assert.strictEqual(storedSeen, MEMBER_SIZE);
+    } finally {
+      await zip.close();
+    }
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}, { timeout: 30 * 60 * 1000 });


### PR DESCRIPTION
Add ZIP archive support to the node:zlib module through three classes and a set of helpers:

- ZipEntry: a single archive member, with buffered reads (content()), bounded-memory streaming reads (contentIterator()), and create()/createStream() for building members.
- ZipFile: random access to an archive backed by a file descriptor, reading members lazily without retaining their content and writing new members in place; opened with open()/openSync().
- ZipBuffer: a zero-copy, in-memory view over an archive already held in a Buffer.

createZipArchive() serializes a sequence of entries into an archive byte stream, and setMaxZipContentSize() bounds the default in-memory decompression size. Every operation has both an asynchronous and a synchronous form.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
