### PR TITLE
vfs: add --vfs and --vfs-manifest startup flags

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1492,7 +1492,9 @@ added: v26.4.0
 
 > Stability: 1 - Experimental
 
-Enable the experimental [`node:vfs`][] module.
+Enable the experimental [`node:vfs`][] module. This flag also gates the
+[`--vfs`][] and [`--vfs-manifest`][] startup flags, which are only allowed
+when `--experimental-vfs` is set.
 
 ### `--experimental-vm-modules`
 
@@ -3527,6 +3529,95 @@ added: v0.1.3
 
 Print node's version.
 
+### `--vfs-manifest=file`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `file` {string} Where to write the manifest. Must be an explicit path -
+  there is no default derived from the [`--vfs`][] target, so a run can
+  never silently overwrite the wrong file.
+
+Requires [`--experimental-vfs`][]. Used together with a directory [`--vfs`][]
+target. The path of every file actually read through the mount during this
+run - by module resolution or by the program's own [`node:fs`][] calls - is
+appended, one per line, to `file` as soon as it's read.
+
+```bash
+node --vfs=./my-app --vfs-manifest=./my-app.manifest main.js
+# -> ./my-app.manifest lists every file this run actually touched
+```
+
+This lets you exercise an app once against its real source directory and
+come away with exactly the list of files it needed, without hand-picking
+what to bundle - useful as an input to building an archive of just those
+files, for example to run later via `--vfs=apparchive.zip`. Throws
+[`ERR_VFS_MANIFEST_REQUIRES_DIRECTORY`][] if [`--vfs`][]'s target is a file
+rather than a directory.
+
+Entries are appended immediately as each file is read, not buffered and
+flushed at the end, so the manifest reflects everything read up to
+whatever point the process reaches - including a process that's killed
+rather than exiting normally. Duplicate reads of the same file are only
+recorded once per thread; a [`Worker`][] appends to the very same manifest
+file directly, since it shares the real file system with the main thread.
+
+### `--vfs=target`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `target` {string} A directory or a ZIP archive to mount.
+
+Requires [`--experimental-vfs`][].
+
+Mounts `target` as a virtual file system ([`node:vfs`][]) and resolves the
+entry point (`process.argv[1]`) and all subsequent `require()`/`import`
+resolution against it, instead of against the real file system.
+
+* If `target` is a directory, it's mounted with a [`RealFSProvider`][] rooted
+  there. The files are already real, so mounting doesn't change what bytes
+  are read - it adds path containment, rejecting resolution that would
+  escape above `target` via `..`.
+* If `target` is a file, it's opened as a ZIP archive ([`zlib.ZipFile`][],
+  read-only) and mounted with a [`ZipProvider`][], turning `target`
+  itself into a virtual directory for module-resolution purposes (e.g.
+  `--vfs=/path/to/app.zip` resolves `/path/to/app.zip/index.js` inside the
+  archive).
+
+`process.argv[1]` becomes the mount root itself, as if `node <target>` had
+been run: the mount's own `package.json` `"main"` (or `index.js`) selects the
+entry point, and any positional command-line argument is the program's own
+(available from `process.argv[2]` onward), never an entry-point override. So a
+ZIP archive can be made directly executable by prepending a shebang line and
+marking it executable:
+
+```console
+$ (printf '#!/usr/bin/env -S node --vfs\n'; cat app.zip) > app && chmod +x app
+$ ./app arg1 arg2   # runs the archive's index.js with ['arg1', 'arg2']
+```
+
+Module resolution under `--vfs` is fully sandboxed: `package.json` lookups,
+`node_modules`-style resolution, and legacy `main` resolution never fall back
+to the real file system once they would step outside the mounted target - a
+dependency has to be inside the mounted directory or archive to be found.
+
+This only affects module _resolution_. The running program's own [`node:fs`][]
+calls to paths outside the mounted target work normally against the real file
+system; only paths under `target` are redirected, the same as any other
+[`node:vfs`][] mount.
+
+Native addons (`.node` files) are supported: from a directory-backed mount
+they're loaded directly from their real underlying path; from an
+archive-backed mount, the addon's bytes are extracted to a content-hashed
+file under the OS temporary directory before being loaded, and that file is
+best-effort removed when the process exits.
+
+A [`Worker`][] created from a process started with `--vfs` inherits the same
+mount unless its own `execArgv` explicitly overrides it.
+
 ### `--watch`
 
 <!-- YAML
@@ -3945,6 +4036,8 @@ one is included in the list below.
 * `--use-openssl-ca`
 * `--use-system-ca`
 * `--v8-pool-size`
+* `--vfs`
+* `--vfs-manifest`
 * `--watch-kill-signal`
 * `--watch-path`
 * `--watch-preserve-output`
@@ -4448,6 +4541,7 @@ node --stack-trace-limit=12 -p -e "Error.stackTraceLimit" # prints 12
 [`--env-file-if-exists`]: #--env-file-if-existsfile
 [`--env-file`]: #--env-filefile
 [`--experimental-sea-config`]: single-executable-applications.md#1-generating-single-executable-preparation-blobs
+[`--experimental-vfs`]: #--experimental-vfs
 [`--heap-prof-dir`]: #--heap-prof-dir
 [`--import`]: #--importmodule
 [`--no-require-module`]: #--no-require-module
@@ -4459,16 +4553,22 @@ node --stack-trace-limit=12 -p -e "Error.stackTraceLimit" # prints 12
 [`--require`]: #-r---require-module
 [`--use-env-proxy`]: #--use-env-proxy
 [`--use-system-ca`]: #--use-system-ca
+[`--vfs-manifest`]: #--vfs-manifestfile
+[`--vfs`]: #--vfstarget
 [`AsyncLocalStorage`]: async_context.md#class-asynclocalstorage
 [`Buffer`]: buffer.md#class-buffer
 [`CRYPTO_secure_malloc_init`]: https://www.openssl.org/docs/man3.0/man3/CRYPTO_secure_malloc_init.html
 [`ERR_INVALID_TYPESCRIPT_SYNTAX`]: errors.md#err_invalid_typescript_syntax
 [`ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`]: errors.md#err_unsupported_typescript_syntax
+[`ERR_VFS_MANIFEST_REQUIRES_DIRECTORY`]: errors.md#err_vfs_manifest_requires_directory
 [`NODE_OPTIONS`]: #node_optionsoptions
 [`NODE_USE_ENV_PROXY=1`]: #node_use_env_proxy1
 [`NO_COLOR`]: https://no-color.org
+[`RealFSProvider`]: vfs.md#class-realfsprovider
 [`Web Storage`]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API
+[`Worker`]: worker_threads.md#class-worker
 [`YoungGenerationSizeFromSemiSpaceSize`]: https://chromium.googlesource.com/v8/v8.git/+/refs/tags/10.3.129/src/heap/heap.cc#328
+[`ZipProvider`]: vfs.md#class-zipprovider
 [`dns.lookup()`]: dns.md#dnslookuphostname-options-callback
 [`dns.setDefaultResultOrder()`]: dns.md#dnssetdefaultresultorderorder
 [`dnsPromises.lookup()`]: dns.md#dnspromiseslookuphostname-options
@@ -4476,6 +4576,7 @@ node --stack-trace-limit=12 -p -e "Error.stackTraceLimit" # prints 12
 [`import` specifier]: esm.md#import-specifiers
 [`net.getDefaultAutoSelectFamilyAttemptTimeout()`]: net.md#netgetdefaultautoselectfamilyattempttimeout
 [`node:ffi`]: ffi.md
+[`node:fs`]: fs.md
 [`node:sqlite`]: sqlite.md
 [`node:stream/iter`]: stream_iter.md
 [`node:vfs`]: vfs.md
@@ -4486,6 +4587,7 @@ node --stack-trace-limit=12 -p -e "Error.stackTraceLimit" # prints 12
 [`v8.startupSnapshot.addDeserializeCallback()`]: v8.md#v8startupsnapshotadddeserializecallbackcallback-data
 [`v8.startupSnapshot.setDeserializeMainFunction()`]: v8.md#v8startupsnapshotsetdeserializemainfunctioncallback-data
 [`v8.startupSnapshot` API]: v8.md#startup-snapshot-api
+[`zlib.ZipFile`]: zlib.md#class-zlibzipfile
 [asynchronous module customization hooks]: module.md#asynchronous-customization-hooks
 [captured by the built-in snapshot of Node.js]: https://github.com/nodejs/node/blob/b19525a33cc84033af4addd0f80acd4dc33ce0cf/test/parallel/test-bootstrap-modules.js#L24
 [collecting code coverage from tests]: test.md#collecting-code-coverage

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -3477,6 +3477,21 @@ An attempt was made to use something that was already closed.
 While using the Performance Timing API (`perf_hooks`), no valid performance
 entry types are found.
 
+<a id="ERR_VFS_INVALID_TARGET"></a>
+
+### `ERR_VFS_INVALID_TARGET`
+
+The target passed to [`--vfs`][] does not exist, or is neither a regular file
+nor a directory.
+
+<a id="ERR_VFS_MANIFEST_REQUIRES_DIRECTORY"></a>
+
+### `ERR_VFS_MANIFEST_REQUIRES_DIRECTORY`
+
+[`--vfs-manifest`][] was used, but [`--vfs`][]'s target is not a directory.
+Recording reads into a manifest only makes sense when running against a real
+directory.
+
 <a id="ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING"></a>
 
 ### `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`
@@ -4655,6 +4670,8 @@ An error occurred trying to allocate memory. This should never happen.
 [`--force-fips`]: cli.md#--force-fips
 [`--no-addons`]: cli.md#--no-addons
 [`--unhandled-rejections`]: cli.md#--unhandled-rejectionsmode
+[`--vfs-manifest`]: cli.md#--vfs-manifest
+[`--vfs`]: cli.md#--vfstarget
 [`BoundSocket`]: net.md#class-netboundsocket
 [`Class: assert.AssertionError`]: assert.md#class-assertassertionerror
 [`ERR_INCOMPATIBLE_OPTION_PAIR`]: #err_incompatible_option_pair

--- a/doc/api/vfs.md
+++ b/doc/api/vfs.md
@@ -34,9 +34,11 @@ It does not isolate untrusted code from the host file system or from other
 Node.js capabilities. Code that can access a [`VirtualFileSystem`][] instance,
 mount it, select its provider, or pass paths to it is trusted application code.
 
-Mounting a VFS only redirects supported [`node:fs`][] calls whose resolved paths
-are under the mount point. It does not prevent code from using other paths or
-other Node.js APIs to access resources available to the process.
+Mounting a VFS only redirects supported [`node:fs`][] calls (and, since the
+CJS/ESM module loader ultimately resolves and reads files the same way,
+`require()`/`import` resolution) whose resolved paths are under the mount
+point. It does not prevent code from using other paths or other Node.js APIs
+to access resources available to the process.
 [`RealFSProvider`][] maps VFS paths under its configured root and rejects paths
 that resolve outside that root, but that check is not a security boundary.
 [`ZipProvider`][] has no real file-system paths of its own to escape; its
@@ -167,6 +169,10 @@ signatures as their [`node:fs`][] counterparts:
   `fstatSync`
 * Streams: `createReadStream`, `createWriteStream`
 * Watchers: `watch`, `watchFile`, `unwatchFile`
+* `toProviderPath(path)`: converts an absolute mounted path to the
+  provider-relative POSIX path passed to [`VirtualProvider`][] methods -
+  useful for code that needs to reach `vfs.provider` directly, bypassing
+  this class's own `fs`-shaped methods.
 
 #### Callback API
 

--- a/doc/node.1
+++ b/doc/node.1
@@ -812,7 +812,9 @@ filter value to run. See Test tags for details on declaring and
 inheriting tags.
 .
 .It Fl -experimental-vfs
-Enable the experimental \fBnode:vfs\fR module.
+Enable the experimental \fBnode:vfs\fR module. This flag also gates the
+\fB--vfs\fR and \fB--vfs-manifest\fR startup flags, which are only allowed
+when \fB--experimental-vfs\fR is set.
 .
 .It Fl -experimental-vm-modules
 Enable experimental ES Module support in the \fBnode:vm\fR module.
@@ -1757,6 +1759,82 @@ amount of CPUs, but it may diverge in environments such as VMs or containers.
 .It Fl v , Fl -version
 Print node's version.
 .
+.It Fl -vfs-manifest Ns = Ns Ar file
+.Bl -bullet
+.It
+\fBfile\fR \fB<string>\fR Where to write the manifest. Must be an explicit path -
+there is no default derived from the \fB--vfs\fR target, so a run can
+never silently overwrite the wrong file.
+.El
+Requires \fB--experimental-vfs\fR. Used together with a directory \fB--vfs\fR
+target. The path of every file actually read through the mount during this
+run - by module resolution or by the program's own \fBnode:fs\fR calls - is
+appended, one per line, to \fBfile\fR as soon as it's read.
+.Bd -literal
+node --vfs=./my-app --vfs-manifest=./my-app.manifest main.js
+# -> ./my-app.manifest lists every file this run actually touched
+.Ed
+This lets you exercise an app once against its real source directory and
+come away with exactly the list of files it needed, without hand-picking
+what to bundle - useful as an input to building an archive of just those
+files, for example to run later via \fB--vfs=apparchive.zip\fR. Throws
+\fBERR_VFS_MANIFEST_REQUIRES_DIRECTORY\fR if \fB--vfs\fR's target is a file
+rather than a directory.
+Entries are appended immediately as each file is read, not buffered and
+flushed at the end, so the manifest reflects everything read up to
+whatever point the process reaches - including a process that's killed
+rather than exiting normally. Duplicate reads of the same file are only
+recorded once per thread; a \fBWorker\fR appends to the very same manifest
+file directly, since it shares the real file system with the main thread.
+.
+.It Fl -vfs Ns = Ns Ar target
+.Bl -bullet
+.It
+\fBtarget\fR \fB<string>\fR A directory or a ZIP archive to mount.
+.El
+Requires \fB--experimental-vfs\fR.
+Mounts \fBtarget\fR as a virtual file system (\fBnode:vfs\fR) and resolves the
+entry point (\fBprocess.argv[1]\fR) and all subsequent \fBrequire()\fR/\fBimport\fR
+resolution against it, instead of against the real file system.
+.Bl -bullet
+.It
+If \fBtarget\fR is a directory, it's mounted with a \fBRealFSProvider\fR rooted
+there. The files are already real, so mounting doesn't change what bytes
+are read - it adds path containment, rejecting resolution that would
+escape above \fBtarget\fR via \fB..\fR.
+.It
+If \fBtarget\fR is a file, it's opened as a ZIP archive (\fBzlib.ZipFile\fR,
+read-only) and mounted with a \fBZipProvider\fR, turning \fBtarget\fR
+itself into a virtual directory for module-resolution purposes (e.g.
+\fB--vfs=/path/to/app.zip\fR resolves \fB/path/to/app.zip/index.js\fR inside the
+archive).
+.El
+\fBprocess.argv[1]\fR becomes the mount root itself, as if \fBnode <target>\fR had
+been run: the mount's own \fBpackage.json\fR \fB"main"\fR (or \fBindex.js\fR) selects the
+entry point, and any positional command-line argument is the program's own
+(available from \fBprocess.argv[2]\fR onward), never an entry-point override. So a
+ZIP archive can be made directly executable by prepending a shebang line and
+marking it executable:
+.Bd -literal
+$ (printf '#!/usr/bin/env -S node --vfs\\n'; cat app.zip) > app && chmod +x app
+$ ./app arg1 arg2   # runs the archive's index.js with ['arg1', 'arg2']
+.Ed
+Module resolution under \fB--vfs\fR is fully sandboxed: \fBpackage.json\fR lookups,
+\fBnode_modules\fR-style resolution, and legacy \fBmain\fR resolution never fall back
+to the real file system once they would step outside the mounted target - a
+dependency has to be inside the mounted directory or archive to be found.
+This only affects module \fIresolution\fR. The running program's own \fBnode:fs\fR
+calls to paths outside the mounted target work normally against the real file
+system; only paths under \fBtarget\fR are redirected, the same as any other
+\fBnode:vfs\fR mount.
+Native addons (\fB.node\fR files) are supported: from a directory-backed mount
+they're loaded directly from their real underlying path; from an
+archive-backed mount, the addon's bytes are extracted to a content-hashed
+file under the OS temporary directory before being loaded, and that file is
+best-effort removed when the process exits.
+A \fBWorker\fR created from a process started with \fB--vfs\fR inherits the same
+mount unless its own \fBexecArgv\fR explicitly overrides it.
+.
 .It Fl -watch
 Starts Node.js in watch mode.
 When in watch mode, changes in the watched files cause the Node.js process to
@@ -2214,6 +2292,10 @@ one is included in the list below.
 \fB--use-system-ca\fR
 .It
 \fB--v8-pool-size\fR
+.It
+\fB--vfs\fR
+.It
+\fB--vfs-manifest\fR
 .It
 \fB--watch-kill-signal\fR
 .It

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1952,6 +1952,10 @@ E('ERR_USE_AFTER_CLOSE', '%s was closed', Error);
 // This should probably be a `TypeError`.
 E('ERR_VALID_PERFORMANCE_ENTRY_TYPE',
   'At least one valid performance entry type is required', Error);
+E('ERR_VFS_INVALID_TARGET',
+  '%s is not a valid --vfs target: must be an existing file or directory', Error);
+E('ERR_VFS_MANIFEST_REQUIRES_DIRECTORY',
+  '--vfs-manifest requires --vfs to target a directory, got %s', Error);
 E('ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING',
   'A dynamic import callback was not specified.', TypeError);
 E('ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG',

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -157,7 +157,7 @@ const {
 const assert = require('internal/assert');
 const fs = require('fs');
 const path = require('path');
-const internalFsBinding = internalBinding('fs');
+const { internalModuleStat: vfsInternalModuleStat } = require('internal/modules/vfs_resolution');
 const { safeGetenv } = internalBinding('credentials');
 const {
   getCjsConditions,
@@ -278,7 +278,7 @@ function stat(filename) {
     const result = statCache.get(filename);
     if (result !== undefined) { return result; }
   }
-  const result = internalFsBinding.internalModuleStat(filename);
+  const result = vfsInternalModuleStat(filename);
   if (statCache !== null && result >= 0) {
     // Only set cache when `internalModuleStat(filename)` succeeds.
     statCache.set(filename, result);
@@ -2101,7 +2101,9 @@ Module._extensions['.json'] = function(module, filename) {
  */
 Module._extensions['.node'] = function(module, filename) {
   // Be aware this doesn't use `content`
-  return process.dlopen(module, path.toNamespacedPath(filename));
+  const { resolveAddonRealPath } = require('internal/modules/vfs_addons');
+  const realFilename = resolveAddonRealPath(filename) ?? filename;
+  return process.dlopen(module, path.toNamespacedPath(realFilename));
 };
 
 /**

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -10,7 +10,8 @@ const {
 } = primordials;
 const { getOptionValue } = require('internal/options');
 const { getValidatedPath } = require('internal/fs/utils');
-const fsBindings = internalBinding('fs');
+const { getFormatOfExtensionlessFile: vfsGetFormatOfExtensionlessFile } =
+  require('internal/modules/vfs_resolution');
 const { internal: internalConstants } = internalBinding('constants');
 
 const extensionFormatMap = {
@@ -66,7 +67,7 @@ function mimeToFormat(mime) {
  */
 function getFormatOfExtensionlessFile(url) {
   const path = getValidatedPath(url);
-  switch (fsBindings.getFormatOfExtensionlessFile(path)) {
+  switch (vfsGetFormatOfExtensionlessFile(path)) {
     case internalConstants.EXTENSIONLESS_FORMAT_WASM:
       return 'wasm';
     default:

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -32,7 +32,10 @@ const { sep, posix: { relative: relativePosixPath }, resolve, join } = require('
 const { URL, pathToFileURL, fileURLToPath, isURL, URLParse } = require('internal/url');
 const { getCWDURL, setOwnProperty, kEmptyObject } = require('internal/util');
 const { canParse: URLCanParse } = internalBinding('url');
-const { legacyMainResolve: FSLegacyMainResolve } = internalBinding('fs');
+const {
+  legacyMainResolve: FSLegacyMainResolve,
+  internalModuleStat: vfsInternalModuleStat,
+} = require('internal/modules/vfs_resolution');
 const {
   ERR_INPUT_TYPE_NOT_ALLOWED,
   ERR_INVALID_ARG_TYPE,
@@ -49,7 +52,6 @@ const {
 const { defaultGetFormatWithoutErrors } = require('internal/modules/esm/get_format');
 const { getConditionsSet } = require('internal/modules/esm/utils');
 const packageJsonReader = require('internal/modules/package_json_reader');
-const internalFsBinding = internalBinding('fs');
 
 /**
  * @typedef {import('internal/modules/esm/package_config.js').PackageConfig} PackageConfig
@@ -245,7 +247,7 @@ function finalizeResolution(resolved, base, preserveSymlinks) {
     throw err;
   }
 
-  const stats = internalFsBinding.internalModuleStat(
+  const stats = vfsInternalModuleStat(
     StringPrototypeEndsWith(path, '/') ? StringPrototypeSlice(path, -1) : path,
   );
 

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -24,10 +24,15 @@ const {
   },
 } = require('internal/errors');
 const { kEmptyObject } = require('internal/util');
-const modulesBinding = internalBinding('modules');
 const path = require('path');
 const { validateString } = require('internal/validators');
-const internalFsBinding = internalBinding('fs');
+const {
+  internalModuleStat: vfsInternalModuleStat,
+  readPackageJSON: vfsReadPackageJSON,
+  getNearestParentPackageJSON: vfsGetNearestParentPackageJSON,
+  getPackageScopeConfig: vfsGetPackageScopeConfig,
+  getPackageType: vfsGetPackageType,
+} = require('internal/modules/vfs_resolution');
 
 
 /**
@@ -122,7 +127,7 @@ const requiresJSONParse = (value) => (value !== undefined && (value[0] === '[' |
 function read(jsonPath, { base, specifier, isESM } = kEmptyObject) {
   // This function will be called by both CJS and ESM, so we need to make sure
   // non-null attributes are converted to strings.
-  const parsed = modulesBinding.readPackageJSON(
+  const parsed = vfsReadPackageJSON(
     jsonPath,
     isESM,
     base == null ? undefined : `${base}`,
@@ -170,7 +175,7 @@ function getNearestParentPackageJSON(checkPath) {
     return deserializedPackageJSONCache.get(parentPackageJSONPath);
   }
 
-  const result = modulesBinding.getNearestParentPackageJSON(checkPath);
+  const result = vfsGetNearestParentPackageJSON(checkPath);
   const packageConfig = deserializePackageJSON(checkPath, result);
 
   moduleToParentPackageJSONCache.set(checkPath, packageConfig.path);
@@ -190,7 +195,7 @@ function getNearestParentPackageJSON(checkPath) {
  * @returns {import('typings/internalBinding/modules').PackageConfig} - The package configuration.
  */
 function getPackageScopeConfig(resolved) {
-  const result = modulesBinding.getPackageScopeConfig(`${resolved}`);
+  const result = vfsGetPackageScopeConfig(`${resolved}`);
 
   if (ArrayIsArray(result)) {
     const { data, exists, path } = deserializePackageJSON(`${resolved}`, result);
@@ -219,8 +224,7 @@ function getPackageScopeConfig(resolved) {
  * @returns {string}
  */
 function getPackageType(url) {
-  const type = modulesBinding.getPackageType(`${url}`);
-  return type ?? 'none';
+  return vfsGetPackageType(`${url}`);
 }
 
 const invalidPackageNameRegEx = /^\.|%|\\/;
@@ -280,7 +284,7 @@ function getPackageJSONURL(specifier, base) {
   let packageJSONPath = fileURLToPath(packageJSONUrl);
   let lastPath;
   do {
-    const stat = internalFsBinding.internalModuleStat(
+    const stat = vfsInternalModuleStat(
       StringPrototypeSlice(packageJSONPath, 0, packageJSONPath.length - 13),
     );
     // Check for !stat.isDirectory()

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -5,7 +5,7 @@ const {
   globalThis,
 } = primordials;
 
-const { getNearestParentPackageJSONType } = internalBinding('modules');
+const { getNearestParentPackageJSONType } = require('internal/modules/vfs_resolution');
 const { getOptionValue } = require('internal/options');
 const path = require('path');
 const { pathToFileURL, URL } = require('internal/url');

--- a/lib/internal/modules/vfs_addons.js
+++ b/lib/internal/modules/vfs_addons.js
@@ -1,0 +1,106 @@
+'use strict';
+
+// Native addon ('.node' file) loading for a path inside an active VFS
+// mount (whether mounted via the --vfs CLI flag or from plain userland
+// code - internal/vfs/setup.js's activeVFSList covers both the same way).
+// `dlopen()` needs a real path on disk - there's nothing to intercept at
+// the fs-module level for that - so:
+//  - a directory-backed mount (RealFSProvider) already has a real
+//    underlying file; translate the virtual path back to it and dlopen
+//    that directly, no copying needed.
+//  - an archive-backed mount (ZipProvider) has no real backing file;
+//    extract the entry's bytes to a real temp file named by content hash
+//    (so repeated loads of the same addon within this process reuse the
+//    same extraction instead of re-extracting) and dlopen that instead.
+//    Each process gets its own pid-scoped temp directory - sharing one
+//    across processes would let one process delete or overwrite a file
+//    another process still has mapped. Extracted files are best-effort
+//    removed when the process exits.
+
+const {
+  SafeSet,
+} = primordials;
+
+const { createHash } = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { findVFSForPath } = require('internal/vfs/setup');
+
+const extractedAddons = new SafeSet();
+let cleanupRegistered = false;
+
+function registerCleanup() {
+  if (cleanupRegistered) { return; }
+  cleanupRegistered = true;
+  process.once('exit', () => {
+    for (const extractedPath of extractedAddons) {
+      try {
+        fs.unlinkSync(extractedPath);
+      } catch {
+        // Best effort: the file may still be mapped (Windows keeps loaded
+        // DLLs locked).
+      }
+    }
+  });
+}
+
+/**
+ * Extracts a VFS-internal addon to a real, content-hashed temp file (or
+ * reuses one already extracted with the same content) and returns its path.
+ * @param {import('internal/vfs/file_system').VirtualFileSystem} vfs
+ * @param {string} vfsPath
+ * @returns {string}
+ */
+function extractAddon(vfs, vfsPath) {
+  const content = vfs.readFileSync(vfsPath);
+  const hash = createHash('sha256').update(content).digest('hex');
+  const dir = path.join(os.tmpdir(), `node-vfs-addons-${process.pid}`);
+  const dest = path.join(dir, `${hash}.node`);
+
+  if (!fs.existsSync(dest)) {
+    fs.mkdirSync(dir, { recursive: true });
+    const tmpDest = `${dest}.${process.pid}.tmp`;
+    fs.writeFileSync(tmpDest, content);
+    try {
+      fs.renameSync(tmpDest, dest);
+    } catch (err) {
+      // Another thread in this process (e.g. a worker_thread, which shares
+      // our pid and thus our temp directory) extracting the same content
+      // may have won the race; that's fine as long as the destination
+      // exists now.
+      try {
+        fs.unlinkSync(tmpDest);
+      } catch {
+        // Ignore: best-effort cleanup of our own losing-race temp file.
+      }
+      if (!fs.existsSync(dest)) { throw err; }
+    }
+  }
+
+  extractedAddons.add(dest);
+  registerCleanup();
+  return dest;
+}
+
+/**
+ * Resolves the real, on-disk path to `dlopen()` for a native addon whose
+ * virtual path is under an active VFS mount.
+ * @param {string} vfsPath
+ * @returns {string | null} The real path to dlopen, or null if `vfsPath` is
+ *   not under an active VFS mount (the caller should dlopen it unchanged).
+ */
+function resolveAddonRealPath(vfsPath) {
+  const found = findVFSForPath(vfsPath);
+  if (found === null) { return null; }
+  const { vfs, normalized } = found;
+  const provider = vfs.provider;
+  if (typeof provider.toRealPath === 'function') {
+    return provider.toRealPath(vfs.toProviderPath(normalized));
+  }
+  return extractAddon(vfs, normalized);
+}
+
+module.exports = {
+  resolveAddonRealPath,
+};

--- a/lib/internal/modules/vfs_resolution.js
+++ b/lib/internal/modules/vfs_resolution.js
@@ -1,0 +1,287 @@
+'use strict';
+
+// The CJS/ESM loader mostly resolves and reads files through the public
+// `fs` module, which any active VFS mount (internal/vfs/setup.js's
+// activeVFSList, populated by every vfs.mount() call - whether from the
+// --vfs CLI flag or from plain userland code) already redirects for any
+// path under that mount. But a handful of module-resolution primitives
+// bypass `fs` entirely and call straight into
+// internalBinding('fs')/internalBinding('modules'), hitting the real
+// filesystem no matter what's mounted. This file provides VFS-aware
+// replacements for exactly those primitives, each matching the native
+// function's contract precisely: when the given path is under an active
+// VFS mount, do the equivalent work against that VirtualFileSystem
+// (bounded at the mount's own root - never falling through past it into the
+// real, unmounted parent directory); otherwise call the real native
+// binding, unchanged.
+
+const {
+  ArrayIsArray,
+  JSONParse,
+  JSONStringify,
+  StringPrototypeEndsWith,
+} = primordials;
+
+const { Buffer } = require('buffer');
+const path = require('path');
+const {
+  codes: {
+    ERR_INVALID_PACKAGE_CONFIG,
+  },
+} = require('internal/errors');
+const { findVFSForPath } = require('internal/vfs/setup');
+
+const internalFsBinding = internalBinding('fs');
+const modulesBinding = internalBinding('modules');
+const { internal: internalConstants } = internalBinding('constants');
+
+/**
+ * VFS-aware replacement for internalBinding('fs').internalModuleStat: -2
+ * (not found/error), 0 (file), or 1 (directory) - callers only ever check
+ * `>= 0` vs not, so any error collapses to -2 like a plain ENOENT would.
+ * @param {string} filename
+ * @returns {number}
+ */
+function internalModuleStat(filename) {
+  const found = findVFSForPath(filename);
+  if (found === null) { return internalFsBinding.internalModuleStat(filename); }
+  try {
+    return found.vfs.statSync(found.normalized).isDirectory() ? 1 : 0;
+  } catch {
+    return -2;
+  }
+}
+
+/**
+ * Reads and minimally parses a package.json at an exact path, matching the
+ * shape `src/node_modules.cc`'s `PackageConfig::Serialize` produces:
+ * `[name, main, type, imports, exports, filePath]`, or `undefined` if the
+ * file doesn't exist. `imports`/`exports` are re-serialized to a JSON string
+ * when they're objects/arrays, exactly like the native reader, so
+ * `package_json_reader.js`'s existing lazy-parse-on-access getters keep
+ * working unchanged.
+ * @param {import('internal/vfs/file_system').VirtualFileSystem} vfs
+ * @param {string} jsonPath
+ * @returns {Array | undefined}
+ */
+function readPackageJSONFile(vfs, jsonPath) {
+  let raw;
+  try {
+    raw = vfs.readFileSync(jsonPath, 'utf8');
+  } catch (err) {
+    if (err?.code === 'ENOENT' || err?.code === 'ENOTDIR') { return undefined; }
+    throw err;
+  }
+  let parsed;
+  try {
+    parsed = JSONParse(raw);
+  } catch (err) {
+    throw new ERR_INVALID_PACKAGE_CONFIG(jsonPath, undefined, err.message);
+  }
+  if (parsed === null || typeof parsed !== 'object' || ArrayIsArray(parsed)) {
+    throw new ERR_INVALID_PACKAGE_CONFIG(jsonPath, undefined, 'not an object');
+  }
+  const name = typeof parsed.name === 'string' ? parsed.name : undefined;
+  const main = typeof parsed.main === 'string' ? parsed.main : undefined;
+  const type = parsed.type === 'commonjs' || parsed.type === 'module' ? parsed.type : 'none';
+  const toRaw = (value) => {
+    if (typeof value === 'string') { return value; }
+    if (typeof value === 'object' && value !== null) { return JSONStringify(value); }
+    return undefined;
+  };
+  const imports = toRaw(parsed.imports);
+  const exports = toRaw(parsed.exports);
+  return [name, main, type, imports, exports, jsonPath];
+}
+
+/**
+ * VFS-aware replacement for internalBinding('modules').readPackageJSON:
+ * reads one exact package.json path (no directory walking).
+ * @param {string} jsonPath
+ * @param {boolean} isESM
+ * @param {string} [base]
+ * @param {string} [specifier]
+ * @returns {Array | undefined}
+ */
+function readPackageJSON(jsonPath, isESM, base, specifier) {
+  const found = findVFSForPath(jsonPath);
+  if (found === null) { return modulesBinding.readPackageJSON(jsonPath, isESM, base, specifier); }
+  return readPackageJSONFile(found.vfs, found.normalized);
+}
+
+/**
+ * Shared directory-climbing algorithm behind getNearestParentPackageJSON()/
+ * getNearestParentPackageJSONType(): starting at the directory containing
+ * `fromPath`, look for a package.json, then climb toward the mount's root -
+ * stopping (not found) at a directory literally named node_modules, or the
+ * moment climbing further would step outside the mount, whichever comes
+ * first. Never falls through to the real parent directory above the mount.
+ * @param {import('internal/vfs/file_system').VirtualFileSystem} vfs
+ * @param {string} fromPath
+ * @returns {Array | undefined}
+ */
+function findPackageJSONUpward(vfs, fromPath) {
+  let dir = path.dirname(fromPath);
+  while (true) {
+    if (path.basename(dir) === 'node_modules') { return undefined; }
+    const found = readPackageJSONFile(vfs, path.join(dir, 'package.json'));
+    if (found !== undefined) { return found; }
+    if (dir === vfs.mountPoint) { return undefined; }
+    const parent = path.dirname(dir);
+    if (parent === dir) { return undefined; }
+    dir = parent;
+  }
+}
+
+/**
+ * VFS-aware replacement for
+ * internalBinding('modules').getNearestParentPackageJSON.
+ * @param {string} checkPath
+ * @returns {Array | undefined}
+ */
+function getNearestParentPackageJSON(checkPath) {
+  const found = findVFSForPath(checkPath);
+  if (found === null) { return modulesBinding.getNearestParentPackageJSON(checkPath); }
+  return findPackageJSONUpward(found.vfs, found.normalized);
+}
+
+/**
+ * VFS-aware replacement for
+ * internalBinding('modules').getNearestParentPackageJSONType.
+ * @param {string} checkPath
+ * @returns {string | undefined}
+ */
+function getNearestParentPackageJSONType(checkPath) {
+  const found = findVFSForPath(checkPath);
+  if (found === null) { return modulesBinding.getNearestParentPackageJSONType(checkPath); }
+  const result = findPackageJSONUpward(found.vfs, found.normalized);
+  return result === undefined ? undefined : result[2];
+}
+
+/**
+ * Shared directory-climbing algorithm behind getPackageScopeConfig()/
+ * getPackageType(): starting at the *same* directory as `resolvedPath`
+ * itself (matching the native "./package.json"-relative-to-self behavior),
+ * climb toward the mount root, stopping at a candidate that would live
+ * directly inside a node_modules directory, or at the mount's own root.
+ * @param {import('internal/vfs/file_system').VirtualFileSystem} vfs
+ * @param {string} resolvedPath
+ * @param {boolean} returnOnlyType
+ * @returns {Array | string | undefined}
+ */
+function findPackageScopeConfig(vfs, resolvedPath, returnOnlyType) {
+  const nodeModulesBoundary = path.join('node_modules', 'package.json');
+  let dir = path.dirname(resolvedPath);
+  while (true) {
+    const candidate = path.join(dir, 'package.json');
+    if (StringPrototypeEndsWith(candidate, nodeModulesBoundary)) { break; }
+    const found = readPackageJSONFile(vfs, candidate);
+    if (found !== undefined) { return returnOnlyType ? found[2] : found; }
+    if (dir === vfs.mountPoint) { break; }
+    const parent = path.dirname(dir);
+    if (parent === dir) { break; }
+    dir = parent;
+  }
+  return returnOnlyType ? undefined : path.join(dir, 'package.json');
+}
+
+/**
+ * @param {string | URL} resolved
+ * @returns {object | string}
+ */
+function getPackageScopeConfig(resolved) {
+  const resolvedPath = `${resolved}`;
+  const found = findVFSForPath(resolvedPath);
+  if (found === null) { return modulesBinding.getPackageScopeConfig(resolvedPath); }
+  return findPackageScopeConfig(found.vfs, found.normalized, false);
+}
+
+/**
+ * @param {string | URL} url
+ * @returns {string}
+ */
+function getPackageType(url) {
+  const resolvedPath = `${url}`;
+  const found = findVFSForPath(resolvedPath);
+  if (found === null) { return modulesBinding.getPackageType(resolvedPath) ?? 'none'; }
+  return findPackageScopeConfig(found.vfs, found.normalized, true) ?? 'none';
+}
+
+// Same order/semantics as esm/resolve.js's own legacyMainResolveExtensions -
+// duplicated here (rather than imported) to avoid a dependency cycle between
+// this file and the ESM resolver; both must stay in sync with
+// src/node_file.cc's `legacy_main_extensions`.
+const legacyMainExtensions = [
+  '', '.js', '.json', '.node',
+  '/index.js', '/index.json', '/index.node',
+  '/index.js', '/index.json', '/index.node',
+];
+const kWithMainEnd = 7;
+
+/**
+ * VFS-aware replacement for internalBinding('fs').legacyMainResolve.
+ * @param {string} packagePath
+ * @param {string} [main]
+ * @param {string} [base]
+ * @returns {number | undefined}
+ */
+function legacyMainResolve(packagePath, main, base) {
+  const found = findVFSForPath(packagePath);
+  if (found === null) { return internalFsBinding.legacyMainResolve(packagePath, main, base); }
+  const { vfs, normalized } = found;
+
+  const isFile = (candidate) => {
+    try {
+      return !vfs.statSync(candidate).isDirectory();
+    } catch {
+      return false;
+    }
+  };
+
+  if (typeof main === 'string') {
+    const initial = path.resolve(normalized, main);
+    for (let i = 0; i < kWithMainEnd; i++) {
+      if (isFile(initial + legacyMainExtensions[i])) { return i; }
+    }
+  }
+
+  const initial = path.resolve(normalized, './index');
+  for (let i = kWithMainEnd; i < legacyMainExtensions.length; i++) {
+    if (isFile(initial + legacyMainExtensions[i])) { return i; }
+  }
+  return undefined;
+}
+
+const WASM_MAGIC = Buffer.from([0x00, 0x61, 0x73, 0x6d]);
+
+/**
+ * VFS-aware replacement for
+ * internalBinding('fs').getFormatOfExtensionlessFile.
+ * @param {string} filePath
+ * @returns {number}
+ */
+function getFormatOfExtensionlessFile(filePath) {
+  const found = findVFSForPath(filePath);
+  if (found === null) { return internalFsBinding.getFormatOfExtensionlessFile(filePath); }
+  try {
+    const content = found.vfs.readFileSync(found.normalized);
+    if (content.length >= 4 && content[0] === WASM_MAGIC[0] && content[1] === WASM_MAGIC[1] &&
+        content[2] === WASM_MAGIC[2] && content[3] === WASM_MAGIC[3]) {
+      return internalConstants.EXTENSIONLESS_FORMAT_WASM;
+    }
+  } catch {
+    // Matches the native function's own fallback on open/read failure.
+  }
+  return internalConstants.EXTENSIONLESS_FORMAT_JAVASCRIPT;
+}
+
+module.exports = {
+  internalModuleStat,
+  readPackageJSON,
+  getNearestParentPackageJSON,
+  getNearestParentPackageJSONType,
+  getPackageScopeConfig,
+  getPackageType,
+  legacyMainResolve,
+  getFormatOfExtensionlessFile,
+};

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -2,6 +2,7 @@
 
 const {
   ArrayPrototypeForEach,
+  ArrayPrototypeSplice,
   Date,
   DatePrototypeGetDate,
   DatePrototypeGetFullYear,
@@ -32,6 +33,7 @@ const {
 const {
   ERR_MISSING_OPTION,
   ERR_ACCESS_DENIED,
+  ERR_VFS_INVALID_TARGET,
 } = require('internal/errors').codes;
 const assert = require('internal/assert');
 const {
@@ -107,8 +109,17 @@ function prepareExecution(options) {
 
   refreshRuntimeOptions();
 
+  // Needed before setupVfsMount() below: mounting a VFS logs through
+  // internal/util/debuglog, which throws if used before this runs.
+  setupDebugEnv();
+
+  // If --vfs is active, mount it before resolving the main entry point below,
+  // since that resolution needs to anchor on the mount's root rather than
+  // the real cwd.
+  const vfsMountTarget = setupVfsMount();
+
   // Patch the process object and get the resolved main entry point.
-  const mainEntry = patchProcessObject(expandArgv1);
+  const mainEntry = patchProcessObject(expandArgv1, vfsMountTarget);
   setupTraceCategoryState();
   setupInspectorHooks();
   setupNetworkInspection();
@@ -124,7 +135,6 @@ function prepareExecution(options) {
   setupWebsocket();
   setupEventsource();
   setupCodeCoverage();
-  setupDebugEnv();
   // Process initial diagnostic reporting configuration, if present.
   initializeReport();
 
@@ -260,9 +270,11 @@ function refreshRuntimeOptions() {
  * Replace `process.argv[1]` with the resolved absolute file path of the entry point, if found.
  * @param {boolean} expandArgv1 - Whether to replace `process.argv[1]` with the resolved absolute file path of
  *   the main entry point.
+ * @param {string} [vfsMountTarget] - The resolved --vfs target, if active; process.argv[1] is then unconditionally
+ *   set to it, and whatever the user actually passed shifts down to argv[2] onward.
  * @returns {string}
  */
-function patchProcessObject(expandArgv1) {
+function patchProcessObject(expandArgv1, vfsMountTarget) {
   const binding = internalBinding('process_methods');
   binding.patchProcessObject(process);
 
@@ -281,10 +293,29 @@ function patchProcessObject(expandArgv1) {
 
   /** @type {string} */
   let mainEntry;
-  // If requested, update process.argv[1] to replace whatever the user provided with the resolved absolute file path of
-  // the entry point.
-  if (expandArgv1 && process.argv[1] && process.argv[1][0] !== '-') {
-    // Expand process.argv[1] into a full path.
+  if (expandArgv1 && vfsMountTarget !== undefined) {
+    // With --vfs active, argv[1] is unconditionally the mount root itself -
+    // as if the user had run `node <mountRoot>` directly - so normal
+    // package.json "main"/index.js resolution decides what actually runs,
+    // the same way it would for any other directory. A positional argument
+    // is never an entry-point override here; it is a user argument, so shift
+    // it (and everything after it) down to argv[2] onward. This is what a
+    // self-mounting shebang line (`#!/usr/bin/env node --vfs`) needs: the
+    // kernel appends the script's own path as the argument that becomes
+    // --vfs's value, so the first argument the *user* supplies on the
+    // command line is what would otherwise land in argv[1] and be misread
+    // as an entry-point path instead of the app's own argument. Workers are
+    // unaffected - they are prepared with expandArgv1 false and name their
+    // entry through `new Worker(filename)`, not argv[1].
+    mainEntry = vfsMountTarget;
+    if (process.argv[1] !== undefined) {
+      ArrayPrototypeSplice(process.argv, 1, 0, mainEntry);
+    } else {
+      process.argv[1] = mainEntry;
+    }
+  } else if (expandArgv1 && process.argv[1] && process.argv[1][0] !== '-') {
+    // If requested, update process.argv[1] to replace whatever the user
+    // provided with the resolved absolute file path of the entry point.
     const path = require('path');
     try {
       mainEntry = path.resolve(process.argv[1]);
@@ -439,6 +470,63 @@ function setupVfs() {
 
   const { BuiltinModule } = require('internal/bootstrap/realm');
   BuiltinModule.allowRequireByUsers('vfs');
+}
+
+/**
+ * Mounts the target given via --vfs (a directory or a ZIP archive) at its
+ * own resolved path. Module resolution then finds it the same way any
+ * other VFS mount is found, via internal/vfs/setup.js's activeVFSList.
+ * Must run before patchProcessObject() resolves process.argv[1], since that
+ * resolution needs to anchor on the mount's root rather than the real cwd
+ * when --vfs is active.
+ * @returns {string | undefined} The resolved --vfs target, or undefined if
+ *   --vfs wasn't passed.
+ */
+function setupVfsMount() {
+  const target = getOptionValue('--vfs');
+  if (!target) {
+    if (getOptionValue('--vfs-manifest')) {
+      throw new ERR_MISSING_OPTION('--vfs (required when --vfs-manifest is used)');
+    }
+    return undefined;
+  }
+  emitExperimentalWarning('--vfs');
+
+  const fs = require('fs');
+  const path = require('path');
+  const resolvedTarget = path.resolve(target);
+
+  let stats;
+  try {
+    stats = fs.statSync(resolvedTarget);
+  } catch {
+    throw new ERR_VFS_INVALID_TARGET(resolvedTarget);
+  }
+
+  let provider;
+  const isDirectory = stats.isDirectory();
+  if (isDirectory) {
+    const { RealFSProvider } = require('internal/vfs/providers/real');
+    provider = new RealFSProvider(resolvedTarget);
+  } else if (stats.isFile()) {
+    const { ZipProvider } = require('internal/vfs/providers/archive');
+    const { ZipFile } = require('internal/zip');
+    provider = new ZipProvider(ZipFile.openSync(resolvedTarget));
+  } else {
+    throw new ERR_VFS_INVALID_TARGET(resolvedTarget);
+  }
+
+  const manifestTarget = getOptionValue('--vfs-manifest');
+  if (manifestTarget) {
+    const { startCliVfsManifest } = require('internal/vfs/cli_manifest');
+    startCliVfsManifest(provider, resolvedTarget, isDirectory, path.resolve(manifestTarget));
+  }
+
+  const { VirtualFileSystem } = require('internal/vfs/file_system');
+  const vfs = new VirtualFileSystem(provider, { emitExperimentalWarning: false });
+  vfs.mount(resolvedTarget);
+
+  return resolvedTarget;
 }
 
 function setupWebStorage() {

--- a/lib/internal/vfs/cli_manifest.js
+++ b/lib/internal/vfs/cli_manifest.js
@@ -1,0 +1,78 @@
+'use strict';
+
+// When --vfs-manifest=<file> is active alongside a directory-backed --vfs
+// mount, every file actually read through that mount during this run -
+// whether by module resolution or by the running program's own node:fs
+// calls (e.g. fs.readFile(`${__dirname}/data.txt`) is a completely ordinary
+// pattern, not just requires/imports) - has its VFS-relative path appended,
+// one per line, to <file> as soon as it's read, rather than buffered and
+// flushed at exit: that way nothing is lost if the process is killed rather
+// than exiting normally. Since worker threads share the real filesystem
+// with the main thread (they're threads, not separate processes), every
+// worker just appends to that very same file directly - O_APPEND writes
+// don't interleave/overwrite each other across threads (or processes), so
+// no cross-thread coordination is needed beyond that.
+//
+// This hooks internal/vfs/provider.js's kReadObserver slot rather than
+// patching any method: readFile()/readFileSync() are the one place every
+// read converges (module loader or direct node:fs calls alike, since both
+// route through the same provider), so checking there - once, from code
+// that already runs on every read - is enough on its own.
+
+const {
+  RegExpPrototypeSymbolReplace,
+  SafeSet,
+} = primordials;
+
+const { kReadObserver } = require('internal/vfs/provider');
+
+const kLeadingSlashRE = /^\/+/;
+
+/**
+ * @param {import('internal/vfs/provider').VirtualProvider} provider The
+ *   provider backing the --vfs mount (a RealFSProvider, always, since
+ *   --vfs-manifest requires a directory target).
+ * @param {string} resolvedTarget The resolved --vfs directory target (used
+ *   only for the error message below).
+ * @param {boolean} isDirectory Whether resolvedTarget is a directory -
+ *   already known by the caller (setupVfsMount()), which classified it to
+ *   pick a provider in the first place.
+ * @param {string} manifestPath The resolved --vfs-manifest output path.
+ */
+function startCliVfsManifest(provider, resolvedTarget, isDirectory, manifestPath) {
+  if (!isDirectory) {
+    const {
+      codes: {
+        ERR_VFS_MANIFEST_REQUIRES_DIRECTORY,
+      },
+    } = require('internal/errors');
+    throw new ERR_VFS_MANIFEST_REQUIRES_DIRECTORY(resolvedTarget);
+  }
+
+  const fs = require('fs');
+  if (internalBinding('worker').isMainThread) {
+    // Only the real main thread starts a fresh manifest; a worker thread
+    // appends to whatever the main thread (or an earlier-started worker)
+    // already wrote, rather than wiping it out mid-run. Safe without extra
+    // coordination: a worker can only be spawned by code running after its
+    // spawner's own bootstrap (and thus this truncation) has completed.
+    fs.writeFileSync(manifestPath, '');
+  }
+
+  const seenHere = new SafeSet();
+  provider[kReadObserver] = (providerPath) => {
+    try {
+      const relative = RegExpPrototypeSymbolReplace(kLeadingSlashRE, providerPath, '');
+      if (relative === '' || seenHere.has(relative)) return;
+      seenHere.add(relative);
+      fs.appendFileSync(manifestPath, relative + '\n');
+    } catch {
+      // Best effort: never let this bookkeeping break the actual read that
+      // triggered it.
+    }
+  };
+}
+
+module.exports = {
+  startCliVfsManifest,
+};

--- a/lib/internal/vfs/file_system.js
+++ b/lib/internal/vfs/file_system.js
@@ -185,6 +185,18 @@ class VirtualFileSystem {
 
   /**
    * Converts an absolute mounted path to a provider-relative POSIX path.
+   * Exposed for callers (such as the module loader's native-addon handling)
+   * that need to reach the underlying provider directly, bypassing this
+   * facade's own fs-shaped methods.
+   * @param {string} inputPath The path to convert
+   * @returns {string}
+   */
+  toProviderPath(inputPath) {
+    return this.#toProviderPath(inputPath);
+  }
+
+  /**
+   * Converts an absolute mounted path to a provider-relative POSIX path.
    * If not mounted, treats the path as already provider-relative.
    * @param {string} inputPath The path to convert
    * @returns {string}

--- a/lib/internal/vfs/provider.js
+++ b/lib/internal/vfs/provider.js
@@ -1,6 +1,10 @@
 'use strict';
 
 const {
+  Symbol,
+} = primordials;
+
+const {
   ERR_METHOD_NOT_IMPLEMENTED,
 } = require('internal/errors').codes;
 
@@ -18,6 +22,17 @@ const {
     COPYFILE_EXCL,
   },
 } = internalBinding('constants');
+
+/**
+ * Internal-only hook: when set on a provider instance (never exposed on the
+ * public node:vfs surface - only internal/vfs/cli_manifest.js pokes this),
+ * readFile()/readFileSync() call it with the provider-relative path of
+ * every file actually read, after the read succeeds. Used by --vfs-manifest
+ * to observe every read regardless of whether it came in through
+ * readFileSync, the promise API, or (since both go through open()+handle
+ * underneath) the module loader itself - without patching any method.
+ */
+const kReadObserver = Symbol('kReadObserver');
 
 /**
  * Base class for VFS providers.
@@ -248,7 +263,9 @@ class VirtualProvider {
       (options.flag ?? 'r') : 'r';
     const handle = await this.open(path, flag);
     try {
-      return await handle.readFile(options);
+      const content = await handle.readFile(options);
+      this[kReadObserver]?.(path);
+      return content;
     } finally {
       await handle.close();
     }
@@ -265,7 +282,9 @@ class VirtualProvider {
       (options.flag ?? 'r') : 'r';
     const handle = this.openSync(path, flag);
     try {
-      return handle.readFileSync(options);
+      const content = handle.readFileSync(options);
+      this[kReadObserver]?.(path);
+      return content;
     } finally {
       handle.closeSync();
     }
@@ -615,4 +634,5 @@ class VirtualProvider {
 
 module.exports = {
   VirtualProvider,
+  kReadObserver,
 };

--- a/lib/internal/vfs/providers/real.js
+++ b/lib/internal/vfs/providers/real.js
@@ -11,7 +11,7 @@ const fs = require('fs');
 const path = require('path');
 const { VirtualProvider } = require('internal/vfs/provider');
 const { VirtualFileHandle } = require('internal/vfs/file_handle');
-const { getValidatedPath } = require('internal/fs/utils');
+const { getValidatedPath, vfsState } = require('internal/fs/utils');
 const { setOwnProperty } = require('internal/util');
 const {
   ERR_METHOD_NOT_IMPLEMENTED,
@@ -23,6 +23,29 @@ const {
 } = require('internal/vfs/errors');
 
 const kReadFileUnknownBufferLength = 8192;
+
+/**
+ * Runs `fn` with the global VFS mount hooks (internal/fs/utils's vfsState)
+ * temporarily disabled. RealFSProvider's own path-based `fs.*` calls must
+ * never go through that hook: if this provider's own rootPath happens to
+ * fall under an active VFS mount - notably its own, when mounted at its own
+ * rootPath, as node --vfs=<directory> does - the hook would redirect the
+ * provider's real I/O straight back into itself, recursing forever.
+ * Fd-based calls (RealFileHandle's read/write/fstat/...) are unaffected by
+ * the hook to begin with, since it keys those off virtual fds specifically,
+ * so they don't need this.
+ * @param {Function} fn
+ * @returns {any}
+ */
+function withoutVfsInterception(fn) {
+  const saved = vfsState.handlers;
+  vfsState.handlers = null;
+  try {
+    return fn();
+  } finally {
+    vfsState.handlers = saved;
+  }
+}
 
 /**
  * A file handle that wraps a real file descriptor.
@@ -175,12 +198,12 @@ class RealFileHandle extends VirtualFileHandle {
 
   writeFileSync(data, options) {
     this.#checkClosed('write');
-    fs.writeFileSync(this.#realPath, data, options);
+    withoutVfsInterception(() => fs.writeFileSync(this.#realPath, data, options));
   }
 
   async writeFile(data, options) {
     this.#checkClosed('write');
-    return fs.promises.writeFile(this.#realPath, data, options);
+    return withoutVfsInterception(() => fs.promises.writeFile(this.#realPath, data, options));
   }
 
   statSync(options) {
@@ -262,6 +285,18 @@ class RealFSProvider extends VirtualProvider {
   }
 
   /**
+   * Resolves a VFS-relative path to its real underlying filesystem path,
+   * applying the same root-containment checks as every other method here,
+   * without opening it. Used by the module loader to `dlopen()` a native
+   * addon directly from its real location instead of extracting it.
+   * @param {string} vfsPath
+   * @returns {string}
+   */
+  toRealPath(vfsPath) {
+    return withoutVfsInterception(() => this.#resolvePath(vfsPath));
+  }
+
+  /**
    * Resolves a VFS path to a real filesystem path.
    * Ensures the path doesn't escape the root directory.
    * @param {string} vfsPath The VFS path (relative to provider root)
@@ -333,112 +368,148 @@ class RealFSProvider extends VirtualProvider {
   }
 
   openSync(vfsPath, flags, mode) {
-    const realPath = this.#resolvePath(vfsPath);
-    const fd = fs.openSync(realPath, flags, mode);
-    return new RealFileHandle(vfsPath, flags, mode ?? 0o644, fd, realPath);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      const fd = fs.openSync(realPath, flags, mode);
+      return new RealFileHandle(vfsPath, flags, mode ?? 0o644, fd, realPath);
+    });
   }
 
   async open(vfsPath, flags, mode) {
-    const realPath = this.#resolvePath(vfsPath);
-    return new Promise((resolve, reject) => {
-      fs.open(realPath, flags, mode, (err, fd) => {
-        if (err) reject(err);
-        else resolve(new RealFileHandle(vfsPath, flags, mode ?? 0o644, fd, realPath));
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return new Promise((resolve, reject) => {
+        fs.open(realPath, flags, mode, (err, fd) => {
+          if (err) reject(err);
+          else resolve(new RealFileHandle(vfsPath, flags, mode ?? 0o644, fd, realPath));
+        });
       });
     });
   }
 
   statSync(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.statSync(realPath, options);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.statSync(realPath, options);
+    });
   }
 
   async stat(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.promises.stat(realPath, options);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.promises.stat(realPath, options);
+    });
   }
 
   lstatSync(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath, false);
-    return fs.lstatSync(realPath, options);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath, false);
+      return fs.lstatSync(realPath, options);
+    });
   }
 
   async lstat(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath, false);
-    return fs.promises.lstat(realPath, options);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath, false);
+      return fs.promises.lstat(realPath, options);
+    });
   }
 
   readdirSync(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.readdirSync(realPath, options);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.readdirSync(realPath, options);
+    });
   }
 
   async readdir(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.promises.readdir(realPath, options);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.promises.readdir(realPath, options);
+    });
   }
 
   mkdirSync(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.mkdirSync(realPath, options);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.mkdirSync(realPath, options);
+    });
   }
 
   async mkdir(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.promises.mkdir(realPath, options);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.promises.mkdir(realPath, options);
+    });
   }
 
   rmdirSync(vfsPath) {
-    const realPath = this.#resolvePath(vfsPath);
-    fs.rmdirSync(realPath);
+    withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      fs.rmdirSync(realPath);
+    });
   }
 
   async rmdir(vfsPath) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.promises.rmdir(realPath);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.promises.rmdir(realPath);
+    });
   }
 
   unlinkSync(vfsPath) {
-    const realPath = this.#resolvePath(vfsPath);
-    fs.unlinkSync(realPath);
+    withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      fs.unlinkSync(realPath);
+    });
   }
 
   async unlink(vfsPath) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.promises.unlink(realPath);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.promises.unlink(realPath);
+    });
   }
 
   renameSync(oldVfsPath, newVfsPath) {
-    const oldRealPath = this.#resolvePath(oldVfsPath);
-    const newRealPath = this.#resolvePath(newVfsPath);
-    fs.renameSync(oldRealPath, newRealPath);
+    withoutVfsInterception(() => {
+      const oldRealPath = this.#resolvePath(oldVfsPath);
+      const newRealPath = this.#resolvePath(newVfsPath);
+      fs.renameSync(oldRealPath, newRealPath);
+    });
   }
 
   async rename(oldVfsPath, newVfsPath) {
-    const oldRealPath = this.#resolvePath(oldVfsPath);
-    const newRealPath = this.#resolvePath(newVfsPath);
-    return fs.promises.rename(oldRealPath, newRealPath);
+    return withoutVfsInterception(() => {
+      const oldRealPath = this.#resolvePath(oldVfsPath);
+      const newRealPath = this.#resolvePath(newVfsPath);
+      return fs.promises.rename(oldRealPath, newRealPath);
+    });
   }
 
   readlinkSync(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath, false);
-    const target = fs.readlinkSync(realPath, options);
-    // Translate absolute targets within rootPath to VFS-relative
-    if (path.isAbsolute(target)) {
-      const rootWithSep = this.#rootPath + path.sep;
-      if (target === this.#rootPath) {
-        return '/';
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath, false);
+      const target = fs.readlinkSync(realPath, options);
+      // Translate absolute targets within rootPath to VFS-relative
+      if (path.isAbsolute(target)) {
+        const rootWithSep = this.#rootPath + path.sep;
+        if (target === this.#rootPath) {
+          return '/';
+        }
+        if (StringPrototypeStartsWith(target, rootWithSep)) {
+          return '/' + target.slice(rootWithSep.length).replace(/\\/g, '/');
+        }
       }
-      if (StringPrototypeStartsWith(target, rootWithSep)) {
-        return '/' + target.slice(rootWithSep.length).replace(/\\/g, '/');
-      }
-    }
-    return target;
+      return target;
+    });
   }
 
   async readlink(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath, false);
-    const target = await fs.promises.readlink(realPath, options);
+    const target = await withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath, false);
+      return fs.promises.readlink(realPath, options);
+    });
     // Translate absolute targets within rootPath to VFS-relative
     if (path.isAbsolute(target)) {
       const rootWithSep = this.#rootPath + path.sep;
@@ -457,15 +528,17 @@ class RealFSProvider extends VirtualProvider {
     if (path.isAbsolute(target)) {
       throw createEACCES('symlink', vfsPath);
     }
-    const realPath = this.#resolvePath(vfsPath);
-    const resolvedTarget = path.resolve(path.dirname(realPath), target);
-    const rootWithSep = this.#rootPath.endsWith(path.sep) ?
-      this.#rootPath : this.#rootPath + path.sep;
-    if (resolvedTarget !== this.#rootPath &&
-        !StringPrototypeStartsWith(resolvedTarget, rootWithSep)) {
-      throw createEACCES('symlink', vfsPath);
-    }
-    fs.symlinkSync(target, realPath, type);
+    withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      const resolvedTarget = path.resolve(path.dirname(realPath), target);
+      const rootWithSep = this.#rootPath.endsWith(path.sep) ?
+        this.#rootPath : this.#rootPath + path.sep;
+      if (resolvedTarget !== this.#rootPath &&
+          !StringPrototypeStartsWith(resolvedTarget, rootWithSep)) {
+        throw createEACCES('symlink', vfsPath);
+      }
+      fs.symlinkSync(target, realPath, type);
+    });
   }
 
   async symlink(target, vfsPath, type) {
@@ -473,15 +546,17 @@ class RealFSProvider extends VirtualProvider {
     if (path.isAbsolute(target)) {
       throw createEACCES('symlink', vfsPath);
     }
-    const realPath = this.#resolvePath(vfsPath);
-    const resolvedTarget = path.resolve(path.dirname(realPath), target);
-    const rootWithSep = this.#rootPath.endsWith(path.sep) ?
-      this.#rootPath : this.#rootPath + path.sep;
-    if (resolvedTarget !== this.#rootPath &&
-        !StringPrototypeStartsWith(resolvedTarget, rootWithSep)) {
-      throw createEACCES('symlink', vfsPath);
-    }
-    return fs.promises.symlink(target, realPath, type);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      const resolvedTarget = path.resolve(path.dirname(realPath), target);
+      const rootWithSep = this.#rootPath.endsWith(path.sep) ?
+        this.#rootPath : this.#rootPath + path.sep;
+      if (resolvedTarget !== this.#rootPath &&
+          !StringPrototypeStartsWith(resolvedTarget, rootWithSep)) {
+        throw createEACCES('symlink', vfsPath);
+      }
+      return fs.promises.symlink(target, realPath, type);
+    });
   }
 
   // path.relative handles case-insensitivity on Windows, which matters here
@@ -499,25 +574,33 @@ class RealFSProvider extends VirtualProvider {
   }
 
   realpathSync(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    const resolved = fs.realpathSync(realPath, options);
-    return this.#resolvedToVfsPath(resolved, vfsPath, 'realpath');
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      const resolved = fs.realpathSync(realPath, options);
+      return this.#resolvedToVfsPath(resolved, vfsPath, 'realpath');
+    });
   }
 
   async realpath(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    const resolved = await fs.promises.realpath(realPath, options);
+    const resolved = await withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.promises.realpath(realPath, options);
+    });
     return this.#resolvedToVfsPath(resolved, vfsPath, 'realpath');
   }
 
   accessSync(vfsPath, mode) {
-    const realPath = this.#resolvePath(vfsPath);
-    fs.accessSync(realPath, mode);
+    withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      fs.accessSync(realPath, mode);
+    });
   }
 
   async access(vfsPath, mode) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.promises.access(realPath, mode);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.promises.access(realPath, mode);
+    });
   }
 
   lchmodSync(vfsPath, mode) {
@@ -529,15 +612,19 @@ class RealFSProvider extends VirtualProvider {
   }
 
   copyFileSync(srcVfsPath, destVfsPath, mode) {
-    const srcRealPath = this.#resolvePath(srcVfsPath);
-    const destRealPath = this.#resolvePath(destVfsPath);
-    fs.copyFileSync(srcRealPath, destRealPath, mode);
+    withoutVfsInterception(() => {
+      const srcRealPath = this.#resolvePath(srcVfsPath);
+      const destRealPath = this.#resolvePath(destVfsPath);
+      fs.copyFileSync(srcRealPath, destRealPath, mode);
+    });
   }
 
   async copyFile(srcVfsPath, destVfsPath, mode) {
-    const srcRealPath = this.#resolvePath(srcVfsPath);
-    const destRealPath = this.#resolvePath(destVfsPath);
-    return fs.promises.copyFile(srcRealPath, destRealPath, mode);
+    return withoutVfsInterception(() => {
+      const srcRealPath = this.#resolvePath(srcVfsPath);
+      const destRealPath = this.#resolvePath(destVfsPath);
+      return fs.promises.copyFile(srcRealPath, destRealPath, mode);
+    });
   }
 
   get supportsWatch() {
@@ -545,23 +632,31 @@ class RealFSProvider extends VirtualProvider {
   }
 
   watch(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.watch(realPath, options);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.watch(realPath, options);
+    });
   }
 
   watchAsync(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.promises.watch(realPath, options);
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.promises.watch(realPath, options);
+    });
   }
 
   watchFile(vfsPath, options) {
-    const realPath = this.#resolvePath(vfsPath);
-    return fs.watchFile(realPath, options, () => {});
+    return withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      return fs.watchFile(realPath, options, () => {});
+    });
   }
 
   unwatchFile(vfsPath, listener) {
-    const realPath = this.#resolvePath(vfsPath);
-    fs.unwatchFile(realPath, listener);
+    withoutVfsInterception(() => {
+      const realPath = this.#resolvePath(vfsPath);
+      fs.unwatchFile(realPath, listener);
+    });
   }
 }
 

--- a/lib/internal/vfs/setup.js
+++ b/lib/internal/vfs/setup.js
@@ -688,4 +688,5 @@ function createVfsHandlers() {
 module.exports = {
   registerVFS,
   deregisterVFS,
+  findVFSForPath,
 };

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -5,6 +5,9 @@ const {
   ArrayPrototypeForEach,
   ArrayPrototypeMap,
   ArrayPrototypePush,
+  ArrayPrototypePushApply,
+  ArrayPrototypeSlice,
+  ArrayPrototypeSome,
   AtomicsAdd,
   Float64Array,
   FunctionPrototypeBind,
@@ -19,6 +22,7 @@ const {
   SafeArrayIterator,
   SafeMap,
   String,
+  StringPrototypeStartsWith,
   StringPrototypeTrim,
   Symbol,
   SymbolAsyncDispose,
@@ -30,6 +34,7 @@ const {
 const EventEmitter = require('events');
 const assert = require('internal/assert');
 const path = require('path');
+const { getOptionValue } = require('internal/options');
 const {
   internalEventLoopUtilization,
 } = require('internal/perf/event_loop_utilization');
@@ -203,6 +208,37 @@ class HeapProfileHandle {
   }
 }
 
+/**
+ * A Worker constructed without an explicit `execArgv` already inherits the
+ * parent's whole per-isolate options (including --vfs/--vfs-manifest) via
+ * the native Clone()-on-no-explicit-execArgv path. But one constructed with
+ * an explicit `execArgv` gets a fresh, from-scratch options parse instead -
+ * so without this, code running under a --vfs mount could spawn an
+ * "escaped" worker simply by passing its own execArgv. Force the active
+ * flags along unless the caller already specified their own.
+ * @param {Array<string>} execArgv
+ * @returns {Array<string>}
+ */
+function withInheritedVfsFlags(execArgv) {
+  const toInject = [];
+
+  const vfsTarget = getOptionValue('--vfs');
+  if (vfsTarget && !ArrayPrototypeSome(execArgv, (arg) => StringPrototypeStartsWith(arg, '--vfs='))) {
+    ArrayPrototypePush(toInject, `--vfs=${vfsTarget}`);
+  }
+
+  const vfsManifest = getOptionValue('--vfs-manifest');
+  if (vfsManifest &&
+      !ArrayPrototypeSome(execArgv, (arg) => StringPrototypeStartsWith(arg, '--vfs-manifest='))) {
+    ArrayPrototypePush(toInject, `--vfs-manifest=${vfsManifest}`);
+  }
+
+  if (toInject.length === 0) return execArgv;
+  const result = ArrayPrototypeSlice(execArgv);
+  ArrayPrototypePushApply(result, toInject);
+  return result;
+}
+
 class Worker extends EventEmitter {
   constructor(filename, options = kEmptyObject) {
     throwIfBuildingSnapshot('Creating workers');
@@ -214,8 +250,11 @@ class Worker extends EventEmitter {
       options,
       `isInternal: ${isInternal}`,
     );
-    if (options.execArgv)
-      validateArray(options.execArgv, 'options.execArgv');
+    let execArgv = options.execArgv;
+    if (execArgv) {
+      validateArray(execArgv, 'options.execArgv');
+      execArgv = withInheritedVfsFlags(execArgv);
+    }
 
     let argv;
     if (options.argv) {
@@ -287,7 +326,7 @@ class Worker extends EventEmitter {
     // Set up the C++ handle for the worker, as well as some internal wiring.
     this[kHandle] = new WorkerImpl(url,
                                    env === process.env ? null : env,
-                                   options.execArgv,
+                                   execArgv,
                                    parseResourceLimits(options.resourceLimits),
                                    !!(options.trackUnmanagedFds ?? true),
                                    isInternal,

--- a/src/node.cc
+++ b/src/node.cc
@@ -394,7 +394,12 @@ MaybeLocal<Value> StartExecution(Environment* env,
     return StartExecution(env, "internal/main/watch_mode");
   }
 
-  if (!first_argv.empty() && first_argv != "-") {
+  // An active --vfs mount is itself an entry point: with no positional
+  // argument, argv[1] defaults to the mount root and its package.json
+  // "main"/index.js decides what runs (see patchProcessObject()), so route
+  // to run_main_module rather than falling through to the REPL/stdin.
+  if ((!first_argv.empty() && first_argv != "-") ||
+      !env->options()->vfs.empty()) {
     return StartExecution(env, "internal/main/run_main_module");
   }
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -215,6 +215,15 @@ void EnvironmentOptions::CheckOptions(std::vector<std::string>* errors,
   }
 #endif  // HAVE_OPENSSL
 
+  if (!experimental_vfs) {
+    if (!vfs.empty()) {
+      errors->push_back("--vfs requires --experimental-vfs");
+    }
+    if (!vfs_manifest.empty()) {
+      errors->push_back("--vfs-manifest requires --experimental-vfs");
+    }
+  }
+
   if (heap_snapshot_near_heap_limit < 0) {
     errors->push_back("--heapsnapshot-near-heap-limit must not be negative");
   }
@@ -622,6 +631,18 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddOption("--experimental-vfs",
             "experimental node:vfs module",
             &EnvironmentOptions::experimental_vfs,
+            kAllowedInEnvvar);
+  AddOption("--vfs",
+            "run the entry point and all module resolution against a "
+            "virtual file system mounted from the given directory or ZIP "
+            "archive (requires --experimental-vfs)",
+            &EnvironmentOptions::vfs,
+            kAllowedInEnvvar);
+  AddOption("--vfs-manifest",
+            "used with a directory --vfs target: append the path of every "
+            "file actually read through the mount during this run to the "
+            "given file, one per line (requires --experimental-vfs)",
+            &EnvironmentOptions::vfs_manifest,
             kAllowedInEnvvar);
   AddOption("--experimental-quic",
 #ifndef OPENSSL_NO_QUIC

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -133,6 +133,8 @@ class EnvironmentOptions : public Options {
   bool experimental_sqlite = HAVE_SQLITE;
   bool experimental_stream_iter = EXPERIMENTALS_DEFAULT_VALUE;
   bool experimental_vfs = EXPERIMENTALS_DEFAULT_VALUE;
+  std::string vfs;
+  std::string vfs_manifest;
   bool webstorage = HAVE_SQLITE;
   bool experimental_dtls = EXPERIMENTALS_DEFAULT_VALUE;
   bool experimental_quic = EXPERIMENTALS_DEFAULT_VALUE;

--- a/test/parallel/test-vfs-cli-flag-addons.js
+++ b/test/parallel/test-vfs-cli-flag-addons.js
@@ -1,0 +1,80 @@
+// Flags: --expose-internals
+'use strict';
+
+// Unit-tests internal/modules/vfs_addons's resolveAddonRealPath() directly
+// (rather than through an actual compiled native addon + --vfs child
+// process, which this environment can't build): a directory-backed mount
+// should resolve straight to the real underlying file, no copying; an
+// archive-backed mount should extract to a content-hashed real temp file,
+// reusing it on a repeated resolve of the same content.
+
+const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+}
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const zlib = require('zlib');
+
+const { VirtualFileSystem } = require('internal/vfs/file_system');
+const { RealFSProvider } = require('internal/vfs/providers/real');
+const { ZipProvider } = require('internal/vfs/providers/archive');
+const { resolveAddonRealPath } = require('internal/modules/vfs_addons');
+
+tmpdir.refresh();
+
+// -- directory-backed: returns the real underlying path, no extraction ----
+
+{
+  const dir = path.join(tmpdir.path, 'dir-mount');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'addon.node'), 'fake addon bytes');
+
+  const provider = new RealFSProvider(dir);
+  const vfs = new VirtualFileSystem(provider, { emitExperimentalWarning: false });
+  vfs.mount(dir);
+
+  const vfsPath = path.join(dir, 'addon.node');
+  const realPath = resolveAddonRealPath(vfsPath);
+  assert.strictEqual(realPath, path.join(dir, 'addon.node'));
+  assert.strictEqual(fs.readFileSync(realPath, 'utf8'), 'fake addon bytes');
+
+  // A path outside the mount is left for the caller to handle unchanged.
+  assert.strictEqual(resolveAddonRealPath(path.join(tmpdir.path, 'elsewhere.node')), null);
+
+  vfs.unmount();
+}
+
+// -- archive-backed: extracts to a content-hashed temp file ----------------
+
+(async () => {
+  const dir = path.join(tmpdir.path, 'zip-mount');
+  fs.mkdirSync(dir, { recursive: true });
+  const zipPath = path.join(dir, 'app.zip');
+  const content = Buffer.from('fake addon bytes from zip');
+  const entry = await zlib.ZipEntry.create('addon.node', content, { method: 'store' });
+  const chunks = [];
+  for await (const chunk of zlib.createZipArchive([entry])) chunks.push(chunk);
+  fs.writeFileSync(zipPath, Buffer.concat(chunks));
+
+  const zipFile = await zlib.ZipFile.open(zipPath);
+  const provider = new ZipProvider(zipFile);
+  const vfs = new VirtualFileSystem(provider, { emitExperimentalWarning: false });
+  vfs.mount(zipPath);
+
+  const vfsPath = path.join(zipPath, 'addon.node');
+  const realPath = resolveAddonRealPath(vfsPath);
+
+  const expectedHash = crypto.createHash('sha256').update(content).digest('hex');
+  assert.strictEqual(path.basename(realPath), `${expectedHash}.node`);
+  assert.strictEqual(fs.readFileSync(realPath, 'utf8'), 'fake addon bytes from zip');
+
+  // Resolving the same content again reuses the same extracted file.
+  assert.strictEqual(resolveAddonRealPath(vfsPath), realPath);
+
+  vfs.unmount();
+  await zipFile.close();
+})().then(common.mustCall());

--- a/test/parallel/test-vfs-cli-flag.js
+++ b/test/parallel/test-vfs-cli-flag.js
@@ -1,0 +1,212 @@
+'use strict';
+
+// Exercises the --vfs=<target> startup flag end to end, by actually
+// spawning `node --vfs=<fixture>` against small CJS/ESM fixture trees and
+// ZIP archives built at test time: entry-point resolution, package.json
+// "type"/main-field/node_modules resolution happening entirely inside the
+// mount, the mount being scoped to its own target (not the whole real
+// filesystem), worker_threads inheriting the mount, and a clear error for
+// an invalid target.
+//
+// With --vfs active, argv[1] is unconditionally the mount root - as with
+// `node <dir>` - so fixtures run via their own index.js / package.json
+// "main", and any positional arguments are the app's own (argv[2] onward),
+// never an entry-file override.
+
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const zlib = require('zlib');
+const { spawnSync } = require('child_process');
+
+tmpdir.refresh();
+let fixtureId = 0;
+function nextDir(name) {
+  const dir = path.join(tmpdir.path, `${fixtureId++}-${name}`);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeTree(dir, files) {
+  for (const { 0: name, 1: content } of Object.entries(files)) {
+    const filePath = path.join(dir, name);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content);
+  }
+}
+
+async function zipFromTree(files, dest) {
+  const entries = [];
+  for (const { 0: name, 1: content } of Object.entries(files)) {
+    entries.push(await zlib.ZipEntry.create(name, Buffer.from(content)));
+  }
+  const chunks = [];
+  for await (const chunk of zlib.createZipArchive(entries)) chunks.push(chunk);
+  fs.writeFileSync(dest, Buffer.concat(chunks));
+}
+
+function runVfs(target, extraArgs = []) {
+  return spawnSync(
+    process.execPath,
+    ['--experimental-vfs', `--vfs=${target}`, ...extraArgs],
+    { encoding: 'utf8' },
+  );
+}
+
+(async () => {
+  // -- Basic CJS entry: directory-backed and archive-backed -----------------
+  //
+  // No entry-file argument is ever passed: with --vfs active, argv[1] is
+  // unconditionally the mount root itself, so the mount's own index.js /
+  // package.json "main" decides what runs, exactly as `node <dir>` would.
+
+  const cjsFiles = {
+    'index.js': "console.log('hello from vfs cjs');",
+  };
+
+  {
+    const dir = nextDir('cjs-dir');
+    writeTree(dir, cjsFiles);
+    const result = runVfs(dir);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.strictEqual(result.stdout.trim(), 'hello from vfs cjs');
+  }
+
+  {
+    const dir = nextDir('cjs-zip-src');
+    const zipPath = path.join(dir, 'app.zip');
+    await zipFromTree(cjsFiles, zipPath);
+    const result = runVfs(zipPath);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.strictEqual(result.stdout.trim(), 'hello from vfs cjs');
+  }
+
+  // -- Positional arguments are the app's own, passed straight through as ----
+  // -- argv[2] onward - never treated as an entry-point override. This is ----
+  // -- what lets a self-mounting shebang app (`#!/usr/bin/env node --vfs`) ----
+  // -- take command-line arguments of its own.                            ----
+
+  {
+    const dir = nextDir('argv-passthrough');
+    writeTree(dir, {
+      'index.js': 'console.log(JSON.stringify(process.argv.slice(2)));',
+    });
+    const result = runVfs(dir, ['alpha', 'beta']);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.deepStrictEqual(JSON.parse(result.stdout.trim()), ['alpha', 'beta']);
+  }
+
+  // -- package.json "main" picks the entry file within the mount ------------
+
+  {
+    const dir = nextDir('main-field');
+    writeTree(dir, {
+      'package.json': JSON.stringify({ main: 'src/entry.js' }),
+      'src/entry.js': "console.log('ran package main');",
+    });
+    const result = runVfs(dir);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.strictEqual(result.stdout.trim(), 'ran package main');
+  }
+
+  // -- ESM entry via package.json "type": "module" ---------------------------
+
+  {
+    const dir = nextDir('esm-dir');
+    writeTree(dir, {
+      'package.json': JSON.stringify({ type: 'module' }),
+      'index.js': "console.log('esm entry:', typeof import.meta.url);",
+    });
+    const result = runVfs(dir);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.strictEqual(result.stdout.trim(), 'esm entry: string');
+  }
+
+  // -- Multi-file CJS app: relative require + node_modules resolution -------
+
+  {
+    const dir = nextDir('multi-file');
+    writeTree(dir, {
+      'index.js':
+        "const { greet } = require('./lib/helper.js');\n" +
+        "const pkg = require('mypkg');\n" +
+        "console.log(greet() + '-' + pkg.value);",
+      'lib/helper.js': "module.exports = { greet: () => 'hi' };",
+      'node_modules/mypkg/package.json': JSON.stringify({ name: 'mypkg', main: 'index.js' }),
+      'node_modules/mypkg/index.js': "module.exports = { value: 'pkg-value' };",
+    });
+    const result = runVfs(dir);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.strictEqual(result.stdout.trim(), 'hi-pkg-value');
+  }
+
+  // -- Invalid target ---------------------------------------------------------
+
+  {
+    const missing = path.join(tmpdir.path, 'does-not-exist');
+    const result = runVfs(missing);
+    assert.notStrictEqual(result.status, 0);
+    assert.match(result.stderr, /ERR_VFS_INVALID_TARGET/);
+  }
+
+  // -- Sandbox is scoped to the mount, not the whole real filesystem ---------
+
+  {
+    const dir = nextDir('scoped-dir');
+    const outsideMarker = path.join(tmpdir.path, 'outside-marker.txt');
+    fs.writeFileSync(outsideMarker, 'real content outside the mount');
+    writeTree(dir, {
+      'index.js':
+        "const fs = require('fs');\n" +
+        `console.log(fs.readFileSync(${JSON.stringify(outsideMarker)}, 'utf8'));`,
+    });
+    const result = runVfs(dir);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.strictEqual(result.stdout.trim(), 'real content outside the mount');
+  }
+
+  // -- worker_threads inherits the mount --------------------------------------
+  //
+  // The worker names its entry through `new Worker(__filename)`, resolved via
+  // the (VFS-aware) module loader - independent of the main thread's argv[1].
+
+  {
+    const dir = nextDir('worker-dir');
+    writeTree(dir, {
+      'marker.txt': 'inside the mount',
+      'index.js':
+        "const { Worker, isMainThread, parentPort } = require('worker_threads');\n" +
+        'if (isMainThread) {\n' +
+        '  const w = new Worker(__filename);\n' +
+        "  w.on('message', (msg) => { console.log(msg); });\n" +
+        '} else {\n' +
+        "  const fs = require('fs');\n" +
+        "  const path = require('path');\n" +
+        "  parentPort.postMessage(fs.readFileSync(path.join(__dirname, 'marker.txt'), 'utf8'));\n" +
+        '}',
+    });
+    const result = runVfs(dir);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.strictEqual(result.stdout.trim(), 'inside the mount');
+  }
+
+  // -- --vfs is gated behind --experimental-vfs -------------------------------
+  //
+  // The startup flag is only allowed together with --experimental-vfs; without
+  // it, option validation rejects the invocation before anything runs.
+
+  {
+    const dir = nextDir('gated-dir');
+    writeTree(dir, { 'index.js': "console.log('should not run');" });
+    const result = spawnSync(
+      process.execPath,
+      [`--vfs=${dir}`],
+      { encoding: 'utf8' },
+    );
+    assert.notStrictEqual(result.status, 0);
+    assert.match(result.stderr, /--vfs requires --experimental-vfs/);
+    assert.strictEqual(result.stdout, '');
+  }
+})().then(common.mustCall());

--- a/test/parallel/test-vfs-manifest-flag.js
+++ b/test/parallel/test-vfs-manifest-flag.js
@@ -1,0 +1,140 @@
+'use strict';
+
+// Exercises the --vfs-manifest=<file> startup flag: every file actually
+// read through a directory-backed --vfs mount - whether by module
+// resolution or by the program's own plain fs.readFile*() calls - gets its
+// path appended to <file>; the flag requires an explicit output path (no
+// path is derived from the --vfs target), requires --vfs to be set and to
+// target a directory, and a file read by a worker thread also lands in the
+// same manifest (workers append to the same real file directly).
+
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const zlib = require('zlib');
+const { spawnSync } = require('child_process');
+
+tmpdir.refresh();
+let fixtureId = 0;
+function nextDir(name) {
+  const dir = path.join(tmpdir.path, `${fixtureId++}-${name}`);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeTree(dir, files) {
+  for (const { 0: name, 1: content } of Object.entries(files)) {
+    const filePath = path.join(dir, name);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content);
+  }
+}
+
+function runVfs(args) {
+  return spawnSync(
+    process.execPath,
+    ['--experimental-vfs', ...args],
+    { encoding: 'utf8' },
+  );
+}
+
+function readManifestLines(manifestPath) {
+  return fs.readFileSync(manifestPath, 'utf8').split('\n').filter((l) => l.length > 0);
+}
+
+// -- basic: module reads + a plain fs.readFileSync() both get recorded ----
+
+{
+  const dir = nextDir('basic');
+  const manifestPath = path.join(tmpdir.path, 'basic.manifest');
+  writeTree(dir, {
+    'index.js':
+      "const { greet } = require('./lib/helper.js');\n" +
+      "const fs = require('fs');\n" +
+      "const path = require('path');\n" +
+      'console.log(greet());\n' +
+      "console.log(fs.readFileSync(path.join(__dirname, 'data.txt'), 'utf8'));",
+    'lib/helper.js': "module.exports = { greet: () => 'hi' };",
+    'data.txt': 'some data',
+  });
+  const result = runVfs([`--vfs=${dir}`, `--vfs-manifest=${manifestPath}`]);
+  assert.strictEqual(result.status, 0, result.stderr);
+  assert.strictEqual(result.stdout.trim(), 'hi\nsome data');
+
+  assert.strictEqual(fs.existsSync(manifestPath), true);
+  const lines = readManifestLines(manifestPath);
+  assert.deepStrictEqual(new Set(lines), new Set([
+    'index.js',
+    'lib/helper.js',
+    'data.txt',
+  ]));
+}
+
+// -- requires --vfs -----------------------------------------------------
+
+{
+  const manifestPath = path.join(tmpdir.path, 'unused.manifest');
+  const result = runVfs([`--vfs-manifest=${manifestPath}`, '-e', '0']);
+  assert.notStrictEqual(result.status, 0);
+  assert.match(result.stderr, /ERR_MISSING_OPTION/);
+}
+
+// -- requires --experimental-vfs ----------------------------------------
+
+{
+  const manifestPath = path.join(tmpdir.path, 'gated.manifest');
+  const result = spawnSync(
+    process.execPath,
+    [`--vfs-manifest=${manifestPath}`, '-e', '0'],
+    { encoding: 'utf8' },
+  );
+  assert.notStrictEqual(result.status, 0);
+  assert.match(result.stderr, /--vfs-manifest requires --experimental-vfs/);
+}
+
+// -- requires --vfs to target a directory, not a zip ---------------------
+
+{
+  const dir = nextDir('zip-src');
+  const zipPath = path.join(dir, 'app.zip');
+  const manifestPath = path.join(tmpdir.path, 'zip-src.manifest');
+  (async () => {
+    const entry = await zlib.ZipEntry.create('index.js', Buffer.from("console.log('hi');"));
+    const chunks = [];
+    for await (const chunk of zlib.createZipArchive([entry])) chunks.push(chunk);
+    fs.writeFileSync(zipPath, Buffer.concat(chunks));
+
+    const result = runVfs([`--vfs=${zipPath}`, `--vfs-manifest=${manifestPath}`]);
+    assert.notStrictEqual(result.status, 0);
+    assert.match(result.stderr, /ERR_VFS_MANIFEST_REQUIRES_DIRECTORY/);
+  })().then(common.mustCall());
+}
+
+// -- a file read by a worker thread lands in the same manifest -----------
+
+{
+  const dir = nextDir('worker-dir');
+  const manifestPath = path.join(tmpdir.path, 'worker-dir.manifest');
+  writeTree(dir, {
+    'worker-data.txt': 'read by the worker',
+    'index.js':
+      "const { Worker, isMainThread, parentPort } = require('worker_threads');\n" +
+      'if (isMainThread) {\n' +
+      '  const w = new Worker(__filename);\n' +
+      "  w.on('message', () => {});\n" +
+      '} else {\n' +
+      "  const fs = require('fs');\n" +
+      "  const path = require('path');\n" +
+      "  fs.readFileSync(path.join(__dirname, 'worker-data.txt'), 'utf8');\n" +
+      '  parentPort.postMessage(\'done\');\n' +
+      '}',
+  });
+  const result = runVfs([`--vfs=${dir}`, `--vfs-manifest=${manifestPath}`]);
+  assert.strictEqual(result.status, 0, result.stderr);
+
+  const lines = readManifestLines(manifestPath);
+  assert.ok(lines.includes('worker-data.txt'), `expected worker-data.txt in ${lines}`);
+  assert.ok(lines.includes('index.js'), `expected index.js in ${lines}`);
+}

--- a/test/parallel/test-vfs-mount-require.js
+++ b/test/parallel/test-vfs-mount-require.js
@@ -1,0 +1,73 @@
+// Flags: --experimental-vfs
+'use strict';
+
+// Regression test: module resolution (require()/createRequire()) must work
+// through *any* mounted VFS - not just one mounted via the --vfs CLI flag.
+// internal/modules/vfs_resolution.js's native-bypass replacements
+// (internalModuleStat, package.json reading, legacyMainResolve, ...) look up
+// the active mount via internal/vfs/setup.js's general activeVFSList, the
+// same registry any vfs.mount() call - CLI-driven or plain userland code -
+// registers with. Before this, they only recognized the CLI's own mount,
+// so requiring a file out of a programmatically-mounted VFS (the pattern a
+// single-executable-application bootstrap script uses: mount an embedded
+// ZipBuffer, then createRequire() into it) would fail with MODULE_NOT_FOUND
+// even though plain fs.readFileSync() against the same path worked fine.
+
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const zlib = require('zlib');
+const { createRequire } = require('module');
+const vfs = require('node:vfs');
+
+tmpdir.refresh();
+
+// -- archive-backed, mounted programmatically (no --vfs flag involved) ----
+
+(async () => {
+  const entries = [
+    await zlib.ZipEntry.create('app.js',
+                               Buffer.from("module.exports = require('./lib/helper.js').greet();")),
+    await zlib.ZipEntry.create('lib/helper.js',
+                               Buffer.from("module.exports = { greet: () => 'hi from zip' };")),
+  ];
+  const chunks = [];
+  for await (const chunk of zlib.createZipArchive(entries)) chunks.push(chunk);
+  const archive = Buffer.concat(chunks);
+
+  const zip = new zlib.ZipBuffer(archive);
+  const provider = new vfs.ZipProvider(zip);
+  const myVfs = vfs.create(provider);
+  myVfs.mount('/zip-app');
+
+  // Plain fs calls already worked before this fix; confirm they still do.
+  assert.strictEqual(fs.existsSync('/zip-app/app.js'), true);
+
+  // The actual regression: require() through the same mount.
+  const result = createRequire('/zip-app/_.js')('./app.js');
+  assert.strictEqual(result, 'hi from zip');
+
+  myVfs.unmount();
+})().then(common.mustCall());
+
+// -- directory-backed, mounted programmatically ----------------------------
+
+{
+  const dir = path.join(tmpdir.path, 'dir-app');
+  fs.mkdirSync(path.join(dir, 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'app.js'),
+                   "module.exports = require('./lib/helper.js').greet();");
+  fs.writeFileSync(path.join(dir, 'lib', 'helper.js'),
+                   "module.exports = { greet: () => 'hi from dir' };");
+
+  const provider = new vfs.RealFSProvider(dir);
+  const myVfs = vfs.create(provider);
+  myVfs.mount('/dir-app');
+
+  const result = createRequire('/dir-app/_.js')('./app.js');
+  assert.strictEqual(result, 'hi from dir');
+
+  myVfs.unmount();
+}


### PR DESCRIPTION
Adds --vfs=<target>, which mounts a directory or ZIP archive and resolves the entry point (process.argv[1]) and all subsequent require()/import resolution against it instead of the real filesystem. A directory target is mounted with RealFSProvider at its own real path, gaining path containment it wouldn't otherwise have; a file target is opened as a read-only ZIP archive (zlib.ZipFile) and mounted with ZipProvider, turning that path into a virtual directory. Only paths under the mount are affected - the running program's own node:fs calls to other real paths are untouched, and module resolution never falls back to the real filesystem once it would step outside the mounted target.

With --vfs active, process.argv[1] is unconditionally the mount root, exactly as if `node <mountRoot>` had been run - so the mount's own package.json "main"/index.js decides what runs, and any positional argument is the program's own (shifted to argv[2] onward), never an entry-point override. This makes a self-mounting shebang line (`#!/usr/bin/env node --vfs`) work: the kernel appends the script's own path as the argument that becomes --vfs's value, so the user's first real argument would otherwise land in argv[1] and be misread as an entry path. An active --vfs mount is also treated as an entry point by the C++ startup dispatch, so `node --vfs=<target>` with no positional argument runs the mount rather than falling through to the REPL or stdin. Workers are unaffected: they name their entry through `new Worker(filename)`, resolved against the inherited mount, not argv[1].

Getting there requires four of the CJS/ESM loader's module-resolution primitives - package.json reading, nearest-parent/scope lookup, legacy main resolution, and extensionless-file format sniffing - to stop bypassing the public fs module and calling straight into native bindings, since that bypass is exactly what let them ignore the mount. Each gets a VFS-aware replacement that defers to the real native binding unchanged for anything outside an active mount, so behavior for non-mounted paths is identical to before.

Native addons are supported: a directory-backed mount dlopens the real underlying file directly; an archive-backed mount extracts the addon to a content-hashed temp file first, since there's no real file to point at. Worker threads inherit an active mount automatically in the common case, and explicitly when the caller supplies its own execArgv that omits it, so sandboxed code can't spawn an "escaped" worker.

Also adds --vfs-manifest=<file>, used with a directory --vfs target: the path of every file actually read through the mount - by module resolution or by the program's own node:fs calls - is appended to <file> as it's read, via a small observer hook on the provider base class rather than patching any method. Workers append to the same file directly, since they share the real filesystem with the main thread.

Native addons extracted from an archive-backed VFS mount were written under a single shared node-vfs-addons temp directory, keyed only by content hash. Sharing that directory across processes lets one process delete or overwrite a file another process still has dlopen'd/mapped. Scope the directory per pid (node-vfs-addons-<pid>) so each process owns its own extraction cache.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
